### PR TITLE
feat: BlockSuite 에디터 통합 및 레거시 변환기 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# MATTERMOST BOARDS PLUGIN
+
+**Generated:** 2026-01-23
+**Commit:** 1e99b5f7
+**Branch:** fix-blocksuite-ui-bug
+
+## OVERVIEW
+
+Mattermost Boards plugin (Focalboard) - self-hosted Kanban/project management. Go 1.24+ backend + React 17/TypeScript frontend. Plugin for Mattermost 10.7.0+.
+
+## STRUCTURE
+
+```
+okrbest-plugin-newboards/
+├── server/           # Go backend (plugin → api → app → store)
+│   ├── api/         # HTTP handlers, routing (Gorilla Mux)
+│   ├── app/         # Business logic, permissions
+│   ├── model/       # Domain models (Board, Block, Card)
+│   ├── boards/      # Plugin app initialization
+│   ├── services/    # Store, permissions, notify, metrics
+│   └── ws/          # WebSocket adapter (real-time sync)
+├── webapp/           # React frontend
+│   └── src/
+│       ├── components/   # UI (cardDetail, kanban, table, sidebar)
+│       ├── store/        # Redux Toolkit slices
+│       ├── blocks/       # Block type definitions
+│       ├── widgets/      # Reusable UI primitives
+│       └── properties/   # Property type handlers
+├── conductor/        # Project docs, style guides, tracks
+├── spec-docs/        # Architecture, BlockSuite migration docs
+└── build/            # Build tooling (pluginctl, sync)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add API endpoint | `server/api/{feature}.go` → register in `api.go` | Follow existing handler pattern |
+| Business logic | `server/app/{feature}.go` | Layer between API and Store |
+| DB operations | `server/services/store/sqlstore/` | Squirrel query builder |
+| Add component | `webapp/src/components/` | Functional + hooks |
+| State management | `webapp/src/store/{slice}.ts` | Redux Toolkit |
+| New block type | `webapp/src/blocks/` + `server/model/block.go` | Both ends needed |
+| Card editor | `webapp/src/components/blockSuite/` | BlockSuite/Yjs integration |
+| WebSocket events | `server/ws/plugin_adapter.go` | Real-time broadcasts |
+| DB migrations | `server/services/store/sqlstore/migrations/` | Postgres/MySQL/SQLite |
+
+## CONVENTIONS
+
+### Server (Go)
+- Layer flow: `API → App → Store` (never skip)
+- Errors: `model.NewErrBadRequest()`, `NewErrForbidden()`, etc.
+- Logging: `mlog.Debug/Info/Warn/Error` with structured fields
+- Tests: `*_test.go` in same package
+
+### Webapp (TypeScript/React)
+- Functional components only, hooks for logic
+- Redux Toolkit for all state
+- SCSS with BEM naming, CSS variables for theming
+- Tests: `*.test.tsx` colocated
+
+### Both
+- Korean responses required
+- Match existing patterns in codebase
+- One feature per change
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- **NEVER** skip layers (API directly calling Store)
+- **NEVER** suppress types: `as any`, `@ts-ignore`, `@ts-expect-error`
+- **NEVER** empty catch blocks
+- **NEVER** commit without explicit request
+- **DO NOT** add new dependencies without justification
+- **DO NOT** refactor while fixing bugs
+
+## COMMANDS
+
+```bash
+# Install dependencies
+cd webapp && npm install
+
+# Dev build (current OS only)
+MM_DEBUG=true make dist
+
+# Production build (all platforms)
+make dist
+
+# Deploy to local Mattermost
+make deploy
+
+# Watch mode (auto-reload)
+make watch-plugin
+
+# Tests
+make test                    # All tests
+make server-test             # Go tests
+cd webapp && npm run test    # Jest tests
+
+# Lint
+make check-style
+cd webapp && npm run check   # ESLint + Stylelint
+```
+
+## KEY ENTRY POINTS
+
+| Entry | File | Purpose |
+|-------|------|---------|
+| Plugin main | `server/main.go` | `plugin.ClientMain()` |
+| Plugin hooks | `server/plugin.go` | Mattermost lifecycle |
+| API router | `server/api/api.go` | `RegisterRoutes()` |
+| App init | `server/app/app.go` | `New()` constructor |
+| Webapp entry | `webapp/src/index.tsx` | `Plugin.initialize()` |
+| Redux store | `webapp/src/store/index.ts` | `configureStore()` |
+| Router | `webapp/src/router.tsx` | React Router config |
+
+## API BASE
+
+All REST APIs: `/plugins/focalboard/api/v2/`
+WebSocket: Via Mattermost plugin adapter
+
+| Endpoint | Method | Handler |
+|----------|--------|---------|
+| `/boards` | GET/POST | `api/boards.go` |
+| `/boards/{id}` | GET/PATCH/DELETE | `api/boards.go` |
+| `/boards/{id}/blocks` | GET/POST | `api/blocks.go` |
+| `/cards` | POST | `api/cards.go` |
+| `/cards/{id}/blocksuite/*` | GET/PUT | `api/blocksuite.go` |
+| `/teams/{id}/categories` | GET/POST | `api/categories.go` |
+
+## BLOCKSUITE (EDITOR)
+
+Active migration: legacy Block system → BlockSuite (Yjs CRDT).
+
+| Component | File |
+|-----------|------|
+| Editor entry | `webapp/src/components/blockSuite/BlockSuiteEditor.tsx` |
+| State provider | `webapp/src/components/blockSuite/EditorProvider.tsx` |
+| Init logic | `webapp/src/components/blockSuite/editor/editor.ts` |
+| Migration utils | `webapp/src/utils/blockSuiteUtils.ts` |
+| Backend API | `server/api/blocksuite.go` |
+
+See `spec-docs/blocksuite-migration.md` for details.
+
+## NOTES
+
+- `conductor/` contains existing project docs - check before asking questions
+- `.cursor/rules/` has domain-specific AI rules
+- Plugin ID is `focalboard`, not `boards`
+- Build requires sibling `mattermost` repo clone at `../mattermost`
+- Set `MM_DEBUG=true` for faster dev builds

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,137 @@
+# SERVER (GO BACKEND)
+
+## OVERVIEW
+
+Go 1.24+ backend. Layered architecture: Plugin → BoardsApp → Server → API → App → Store.
+
+## STRUCTURE
+
+```
+server/
+├── main.go           # plugin.ClientMain() entry
+├── plugin.go         # Mattermost plugin hooks
+├── api/              # HTTP handlers (28 files)
+├── app/              # Business logic (43 files)
+├── model/            # Domain models (37 files)
+├── boards/           # Plugin app initialization
+├── services/
+│   ├── store/        # Data access layer
+│   │   ├── store.go      # Interface definition
+│   │   └── sqlstore/     # SQL implementation (Squirrel)
+│   ├── permissions/  # RBAC (Mattermost integrated)
+│   ├── notify/       # @mentions, subscriptions
+│   ├── metrics/      # Prometheus
+│   └── audit/        # Audit logging
+├── ws/               # WebSocket (real-time sync)
+└── utils/            # Helpers
+```
+
+## WHERE TO LOOK
+
+| Task | Primary | Secondary |
+|------|---------|-----------|
+| New API | `api/{feature}.go` | Register in `api/api.go` |
+| Business logic | `app/{feature}.go` | - |
+| New model | `model/{entity}.go` | - |
+| DB queries | `services/store/sqlstore/{entity}.go` | - |
+| Migrations | `services/store/sqlstore/migrations/` | - |
+| WebSocket events | `ws/plugin_adapter.go` | - |
+| Permissions | `services/permissions/mmpermissions/` | - |
+
+## REQUEST FLOW
+
+```
+Client → plugin.ServeHTTP → Mux Router → API Handler
+    → a.sessionRequired() (auth middleware)
+    → a.app.{Method}() (business logic)
+    → a.store.{Method}() (data access)
+    → JSON Response
+```
+
+## CONVENTIONS
+
+### Handler Pattern
+```go
+func (a *API) handleGetBoard(w http.ResponseWriter, r *http.Request) {
+    boardID := mux.Vars(r)["boardID"]
+    userID := getUserID(r)
+    
+    // Permission check
+    if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionViewBoard) {
+        a.errorResponse(w, r, model.NewErrForbidden("access denied"))
+        return
+    }
+    
+    // Business logic
+    board, err := a.app.GetBoard(boardID)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    // Response
+    data, _ := json.Marshal(board)
+    jsonBytesResponse(w, http.StatusOK, data)
+}
+```
+
+### Error Types
+```go
+model.NewErrBadRequest("message")      // 400
+model.NewErrUnauthorized("message")    // 401
+model.NewErrForbidden("message")       // 403
+model.NewErrNotFound("message")        // 404
+```
+
+### Logging
+```go
+a.logger.Debug("message", mlog.String("key", value))
+a.logger.Error("failed", mlog.Err(err))
+```
+
+## KEY MODELS
+
+| Model | File | Key Fields |
+|-------|------|------------|
+| Board | `model/board.go` | ID, TeamID, ChannelID, Type, Title, CardProperties |
+| Block | `model/block.go` | ID, ParentID, BoardID, Type, Title, Fields |
+| Card | `model/card.go` | Block + card-specific fields |
+| BoardMember | `model/board.go` | BoardID, UserID, SchemeAdmin/Editor/Viewer |
+
+## STORE INTERFACE
+
+`services/store/store.go` defines all DB operations. SQLStore implements it.
+
+Key methods:
+- `GetBoard(id)` / `InsertBoard()` / `PatchBoard()`
+- `GetBlocksForBoard(boardID)` / `InsertBlock()` / `PatchBlock()`
+- `GetMembersForBoard(boardID)` / `SaveMember()`
+
+## WEBSOCKET
+
+`ws/plugin_adapter.go` broadcasts changes:
+```go
+a.wsAdapter.BroadcastBlockChange(teamID, block)
+a.wsAdapter.BroadcastBoardChange(teamID, board)
+a.wsAdapter.BroadcastCategoryChange(category)
+```
+
+## ANTI-PATTERNS
+
+- Skip layers (API → Store directly)
+- Return generic errors (always use model.NewErr*)
+- Forget permission checks
+- Hardcode SQL (use Squirrel builder)
+
+## TESTS
+
+```bash
+make server-test                      # All server tests
+go test -v ./server/app/...           # Specific package
+go test -v -run TestName ./server/... # Specific test
+```
+
+Mock generation:
+```bash
+cd server && go generate ./...
+```

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -143,29 +144,50 @@ func (a *App) validateFileReferencedByBoard(boardID, filename string) error {
 		}
 	}
 
-	// Check if this board has any BlockSuite documents (cards with BlockSuite content)
-	// If so, the file might be referenced by BlockSuite editor images
-	// For now, allow files for boards that have BlockSuite-enabled cards
-	cardBlocks, err := a.store.GetBlocksWithType(boardID, model.TypeCard)
-	if err != nil {
-		return err
-	}
-
-	for _, card := range cardBlocks {
-		bsDoc, err := a.store.GetBlockSuiteDocByCardID(card.ID)
-		if err == nil && bsDoc != nil && len(bsDoc.Snapshot) > 0 {
-			// This board has BlockSuite documents, allow file access
-			// The file was uploaded through the BlockSuite editor
-			a.logger.Debug("validateFileReferencedByBoard: allowing file access for BlockSuite-enabled board",
-				mlog.String("boardID", boardID),
-				mlog.String("filename", filename),
-				mlog.String("cardID", card.ID),
-			)
-			return nil
-		}
+	if a.isFileReferencedByBlockSuiteDocs(boardID, filename) {
+		return nil
 	}
 
 	return fmt.Errorf("%w: file %s is not referenced by any block in board %s", ErrFileNotReferencedByBoard, filename, boardID)
+}
+
+func (a *App) isFileReferencedByBlockSuiteDocs(boardID, filename string) bool {
+	docs, err := a.store.GetBlockSuiteDocsByBoardID(boardID)
+	if err != nil {
+		a.logger.Debug("isFileReferencedByBlockSuiteDocs: failed to get docs",
+			mlog.String("boardID", boardID),
+			mlog.Err(err))
+		return false
+	}
+
+	for _, doc := range docs {
+		if doc.Snapshot == nil {
+			continue
+		}
+
+		var snapshot map[string]interface{}
+		if err := json.Unmarshal(doc.Snapshot, &snapshot); err != nil {
+			continue
+		}
+
+		meta, ok := snapshot["meta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		blobMap, ok := meta["blobMap"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, fileID := range blobMap {
+			if fileIDStr, ok := fileID.(string); ok && fileIDStr == filename {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (a *App) GetFile(teamID, boardID, fileName string) (*mm_model.FileInfo, filestore.ReadCloseSeeker, error) {

--- a/server/services/store/mockstore/mockstore.go
+++ b/server/services/store/mockstore/mockstore.go
@@ -460,6 +460,21 @@ func (mr *MockStoreMockRecorder) GetBlockSuiteDocInfoByCardID(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockSuiteDocInfoByCardID", reflect.TypeOf((*MockStore)(nil).GetBlockSuiteDocInfoByCardID), arg0)
 }
 
+// GetBlockSuiteDocsByBoardID mocks base method.
+func (m *MockStore) GetBlockSuiteDocsByBoardID(arg0 string) ([]*model.BlockSuiteDoc, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockSuiteDocsByBoardID", arg0)
+	ret0, _ := ret[0].([]*model.BlockSuiteDoc)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockSuiteDocsByBoardID indicates an expected call of GetBlockSuiteDocsByBoardID.
+func (mr *MockStoreMockRecorder) GetBlockSuiteDocsByBoardID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockSuiteDocsByBoardID", reflect.TypeOf((*MockStore)(nil).GetBlockSuiteDocsByBoardID), arg0)
+}
+
 // GetBlocks mocks base method.
 func (m *MockStore) GetBlocks(arg0 model.QueryBlocksOptions) ([]*model.Block, error) {
 	m.ctrl.T.Helper()

--- a/server/services/store/sqlstore/blocksuite.go
+++ b/server/services/store/sqlstore/blocksuite.go
@@ -12,9 +12,9 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
-// GetBlockSuiteDocByCardID retrieves a BlockSuite document by card_id.
-func (s *SQLStore) GetBlockSuiteDocByCardID(cardID string) (*model.BlockSuiteDoc, error) {
-	query := s.getQueryBuilder(s.db).
+// getBlockSuiteDocByCardID retrieves a BlockSuite document by card_id.
+func (s *SQLStore) getBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) (*model.BlockSuiteDoc, error) {
+	query := s.getQueryBuilder(db).
 		Select(
 			"doc_id",
 			"card_id",
@@ -46,16 +46,16 @@ func (s *SQLStore) GetBlockSuiteDocByCardID(cardID string) (*model.BlockSuiteDoc
 		return nil, model.NewErrBlockSuiteDocNotFound(cardID)
 	}
 	if err != nil {
-		s.logger.Error("GetBlockSuiteDocByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
+		s.logger.Error("getBlockSuiteDocByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
 		return nil, err
 	}
 
 	return doc, nil
 }
 
-// GetBlockSuiteDocInfoByCardID retrieves metadata (without snapshot) by card_id.
-func (s *SQLStore) GetBlockSuiteDocInfoByCardID(cardID string) (*model.BlockSuiteDocInfo, error) {
-	query := s.getQueryBuilder(s.db).
+// getBlockSuiteDocInfoByCardID retrieves metadata (without snapshot) by card_id.
+func (s *SQLStore) getBlockSuiteDocInfoByCardID(db sq.BaseRunner, cardID string) (*model.BlockSuiteDocInfo, error) {
+	query := s.getQueryBuilder(db).
 		Select(
 			"doc_id",
 			"card_id",
@@ -85,21 +85,21 @@ func (s *SQLStore) GetBlockSuiteDocInfoByCardID(cardID string) (*model.BlockSuit
 		return nil, model.NewErrBlockSuiteDocNotFound(cardID)
 	}
 	if err != nil {
-		s.logger.Error("GetBlockSuiteDocInfoByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
+		s.logger.Error("getBlockSuiteDocInfoByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
 		return nil, err
 	}
 
 	return info, nil
 }
 
-// UpsertBlockSuiteDoc inserts or updates a BlockSuite document.
-func (s *SQLStore) UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error {
+// upsertBlockSuiteDoc inserts or updates a BlockSuite document.
+func (s *SQLStore) upsertBlockSuiteDoc(db sq.BaseRunner, doc *model.BlockSuiteDoc) error {
 	if err := doc.IsValid(); err != nil {
 		return err
 	}
 
 	// Verify that the card exists
-	cardExistsQuery := s.getQueryBuilder(s.db).
+	cardExistsQuery := s.getQueryBuilder(db).
 		Select("1").
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{
@@ -114,7 +114,7 @@ func (s *SQLStore) UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error {
 		return fmt.Errorf("card not found: %s", doc.CardID)
 	}
 	if err != nil {
-		s.logger.Error("UpsertBlockSuiteDoc card validation ERROR",
+		s.logger.Error("upsertBlockSuiteDoc card validation ERROR",
 			mlog.String("card_id", doc.CardID),
 			mlog.Err(err))
 		return err
@@ -122,7 +122,7 @@ func (s *SQLStore) UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error {
 
 	// Build upsert query based on database type
 	var query sq.InsertBuilder
-	query = s.getQueryBuilder(s.db).
+	query = s.getQueryBuilder(db).
 		Insert(s.tablePrefix+"blocksuite_docs").
 		Columns(
 			"doc_id",
@@ -176,7 +176,7 @@ func (s *SQLStore) UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error {
 
 	_, err = query.Exec()
 	if err != nil {
-		s.logger.Error("UpsertBlockSuiteDoc ERROR",
+		s.logger.Error("upsertBlockSuiteDoc ERROR",
 			mlog.String("doc_id", doc.DocID),
 			mlog.String("card_id", doc.CardID),
 			mlog.Err(err))
@@ -236,15 +236,15 @@ func (s *SQLStore) GetBlockSuiteDocsByBoardID(boardID string) ([]*model.BlockSui
 	return docs, nil
 }
 
-// DeleteBlockSuiteDocByCardID deletes a BlockSuite document by card_id.
-func (s *SQLStore) DeleteBlockSuiteDocByCardID(cardID string) error {
-	query := s.getQueryBuilder(s.db).
+// deleteBlockSuiteDocByCardID deletes a BlockSuite document by card_id.
+func (s *SQLStore) deleteBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) error {
+	query := s.getQueryBuilder(db).
 		Delete(s.tablePrefix + "blocksuite_docs").
 		Where(sq.Eq{"card_id": cardID})
 
 	result, err := query.Exec()
 	if err != nil {
-		s.logger.Error("DeleteBlockSuiteDocByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
+		s.logger.Error("deleteBlockSuiteDocByCardID ERROR", mlog.String("card_id", cardID), mlog.Err(err))
 		return err
 	}
 

--- a/server/services/store/sqlstore/blocksuite.go
+++ b/server/services/store/sqlstore/blocksuite.go
@@ -13,8 +13,8 @@ import (
 )
 
 // GetBlockSuiteDocByCardID retrieves a BlockSuite document by card_id.
-func (s *SQLStore) getBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) (*model.BlockSuiteDoc, error) {
-	query := s.getQueryBuilder(db).
+func (s *SQLStore) GetBlockSuiteDocByCardID(cardID string) (*model.BlockSuiteDoc, error) {
+	query := s.getQueryBuilder(s.db).
 		Select(
 			"doc_id",
 			"card_id",
@@ -54,8 +54,8 @@ func (s *SQLStore) getBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) (*m
 }
 
 // GetBlockSuiteDocInfoByCardID retrieves metadata (without snapshot) by card_id.
-func (s *SQLStore) getBlockSuiteDocInfoByCardID(db sq.BaseRunner, cardID string) (*model.BlockSuiteDocInfo, error) {
-	query := s.getQueryBuilder(db).
+func (s *SQLStore) GetBlockSuiteDocInfoByCardID(cardID string) (*model.BlockSuiteDocInfo, error) {
+	query := s.getQueryBuilder(s.db).
 		Select(
 			"doc_id",
 			"card_id",
@@ -93,13 +93,13 @@ func (s *SQLStore) getBlockSuiteDocInfoByCardID(db sq.BaseRunner, cardID string)
 }
 
 // UpsertBlockSuiteDoc inserts or updates a BlockSuite document.
-func (s *SQLStore) upsertBlockSuiteDoc(db sq.BaseRunner, doc *model.BlockSuiteDoc) error {
+func (s *SQLStore) UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error {
 	if err := doc.IsValid(); err != nil {
 		return err
 	}
 
 	// Verify that the card exists
-	cardExistsQuery := s.getQueryBuilder(db).
+	cardExistsQuery := s.getQueryBuilder(s.db).
 		Select("1").
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{
@@ -122,8 +122,8 @@ func (s *SQLStore) upsertBlockSuiteDoc(db sq.BaseRunner, doc *model.BlockSuiteDo
 
 	// Build upsert query based on database type
 	var query sq.InsertBuilder
-	query = s.getQueryBuilder(db).
-		Insert(s.tablePrefix + "blocksuite_docs").
+	query = s.getQueryBuilder(s.db).
+		Insert(s.tablePrefix+"blocksuite_docs").
 		Columns(
 			"doc_id",
 			"card_id",
@@ -186,9 +186,59 @@ func (s *SQLStore) upsertBlockSuiteDoc(db sq.BaseRunner, doc *model.BlockSuiteDo
 	return nil
 }
 
+// GetBlockSuiteDocsByBoardID retrieves all BlockSuite documents for a board.
+func (s *SQLStore) GetBlockSuiteDocsByBoardID(boardID string) ([]*model.BlockSuiteDoc, error) {
+	query := s.getQueryBuilder(s.db).
+		Select(
+			"doc_id",
+			"card_id",
+			"board_id",
+			"snapshot",
+			"created_at",
+			"updated_at",
+			"created_by",
+			"updated_by",
+		).
+		From(s.tablePrefix + "blocksuite_docs").
+		Where(sq.Eq{"board_id": boardID})
+
+	rows, err := query.Query()
+	if err != nil {
+		s.logger.Error("GetBlockSuiteDocsByBoardID query ERROR", mlog.String("board_id", boardID), mlog.Err(err))
+		return nil, err
+	}
+	defer rows.Close()
+
+	var docs []*model.BlockSuiteDoc
+	for rows.Next() {
+		doc := &model.BlockSuiteDoc{}
+		err := rows.Scan(
+			&doc.DocID,
+			&doc.CardID,
+			&doc.BoardID,
+			&doc.Snapshot,
+			&doc.CreatedAt,
+			&doc.UpdatedAt,
+			&doc.CreatedBy,
+			&doc.UpdatedBy,
+		)
+		if err != nil {
+			s.logger.Error("GetBlockSuiteDocsByBoardID scan ERROR", mlog.String("board_id", boardID), mlog.Err(err))
+			return nil, err
+		}
+		docs = append(docs, doc)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return docs, nil
+}
+
 // DeleteBlockSuiteDocByCardID deletes a BlockSuite document by card_id.
-func (s *SQLStore) deleteBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) error {
-	query := s.getQueryBuilder(db).
+func (s *SQLStore) DeleteBlockSuiteDocByCardID(cardID string) error {
+	query := s.getQueryBuilder(s.db).
 		Delete(s.tablePrefix + "blocksuite_docs").
 		Where(sq.Eq{"card_id": cardID})
 
@@ -207,4 +257,3 @@ func (s *SQLStore) deleteBlockSuiteDocByCardID(db sq.BaseRunner, cardID string) 
 
 	return nil
 }
-

--- a/server/services/store/store.go
+++ b/server/services/store/store.go
@@ -128,6 +128,7 @@ type Store interface {
 	// BlockSuite document operations
 	GetBlockSuiteDocByCardID(cardID string) (*model.BlockSuiteDoc, error)
 	GetBlockSuiteDocInfoByCardID(cardID string) (*model.BlockSuiteDocInfo, error)
+	GetBlockSuiteDocsByBoardID(boardID string) ([]*model.BlockSuiteDoc, error)
 	// @withTransaction
 	UpsertBlockSuiteDoc(doc *model.BlockSuiteDoc) error
 	DeleteBlockSuiteDocByCardID(cardID string) error

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -1,0 +1,160 @@
+# WEBAPP (REACT FRONTEND)
+
+## OVERVIEW
+
+React 17 + TypeScript frontend. Redux Toolkit state. Webpack build. BlockSuite editor integration (Yjs CRDT).
+
+## STRUCTURE
+
+```
+webapp/
+├── src/
+│   ├── index.tsx         # Plugin entry (Mattermost integration)
+│   ├── app.tsx           # Root App component
+│   ├── router.tsx        # React Router config
+│   ├── store/            # Redux Toolkit (17 slices)
+│   ├── components/       # UI components (118 dirs)
+│   ├── blocks/           # Block type definitions
+│   ├── widgets/          # Reusable primitives
+│   ├── properties/       # Property type handlers
+│   ├── utils/            # Helpers (utils.ts, blockSuiteUtils.ts)
+│   ├── octoClient.ts     # API client (47KB)
+│   ├── mutator.ts        # Optimistic updates (53KB)
+│   └── wsclient.ts       # WebSocket client
+├── webpack.config.js     # Build config
+└── package.json          # Dependencies
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| New component | `src/components/{feature}/` |
+| State slice | `src/store/{slice}.ts` |
+| API calls | `src/octoClient.ts` |
+| Optimistic updates | `src/mutator.ts` |
+| WebSocket handling | `src/wsclient.ts` |
+| Block type | `src/blocks/{type}.ts` |
+| Property type | `src/properties/{type}/` |
+| Card editor | `src/components/blockSuite/` |
+
+## REDUX STORE
+
+Slices in `store/`:
+- `boards.ts` - Board entities
+- `cards.ts` - Card entities  
+- `views.ts` - View configurations
+- `users.ts` - User data
+- `teams.ts` - Team selection
+- `sidebar.ts` - Sidebar state
+- `rhs.ts` - Right-hand sidebar
+
+Usage:
+```tsx
+import {useAppSelector, useAppDispatch} from '../store/hooks'
+import {getBoard} from '../store/boards'
+
+const board = useAppSelector(getBoard)
+```
+
+## COMPONENT PATTERNS
+
+```tsx
+// Functional + hooks only
+const MyComponent: React.FC<Props> = ({prop1}) => {
+    const intl = useIntl()
+    const dispatch = useAppDispatch()
+    const data = useAppSelector(selector)
+    
+    const handleClick = useCallback(() => {
+        // action
+    }, [deps])
+    
+    return <div className='MyComponent'>...</div>
+}
+
+export default React.memo(MyComponent)
+```
+
+## STYLING
+
+SCSS with BEM naming:
+```scss
+.MyComponent {
+    &__header { }
+    &__content { }
+    &--active { }
+}
+```
+
+CSS variables for theming (from Mattermost):
+```scss
+color: var(--center-channel-color);
+background: var(--center-channel-bg);
+```
+
+## API CLIENT
+
+`octoClient.ts` wraps all REST calls:
+```typescript
+await octoClient.getBoard(boardId)
+await octoClient.patchBlock(blockId, patch)
+await octoClient.createCard(card)
+```
+
+## MUTATOR
+
+`mutator.ts` handles optimistic updates with undo:
+```typescript
+await mutator.changePropertyValue(...)
+await mutator.insertBlock(block, description)
+```
+
+## BLOCKSUITE EDITOR
+
+Card content uses BlockSuite (Yjs-based):
+- Entry: `components/blockSuite/BlockSuiteEditor.tsx`
+- State: `components/blockSuite/EditorProvider.tsx`
+- Init: `components/blockSuite/editor/editor.ts`
+- Migration: `utils/blockSuiteUtils.ts`
+
+Auto-save: 2s debounce on Yjs doc changes.
+
+## KEY COMPONENTS
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| CardDetail | `components/cardDetail/` | Card edit dialog |
+| KanbanView | `components/kanban/` | Kanban board |
+| TableView | `components/table/` | Table view |
+| Sidebar | `components/sidebar/` | Navigation |
+| ViewHeader | `components/viewHeader/` | View controls |
+
+## ANTI-PATTERNS
+
+- Class components (use functional + hooks)
+- Direct DOM manipulation
+- Inline styles (use SCSS)
+- Non-memoized callbacks in render
+- Type assertions (`as any`)
+
+## COMMANDS
+
+```bash
+npm install              # Install deps
+npm run build           # Production build
+npm run debug           # Dev build
+npm run test            # Jest tests
+npm run check           # ESLint + Stylelint
+npm run check-types     # TypeScript check
+```
+
+## TESTS
+
+Colocated `*.test.tsx` files:
+```bash
+npm run test                           # All tests
+npm run test -- --watch               # Watch mode
+npm run test -- path/to/file.test.tsx # Specific
+npm run updatesnapshot                # Update snapshots
+```

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -536,5 +536,8 @@
   "BoardMessage.cardNotify": "@{username} notified about card [{cardTitle}]({cardLink}) in board [{boardTitle}]({boardLink})",
   "BlockSuiteEditor.loading": "Loading editor...",
   "BlockSuiteEditor.error": "Failed to load editor",
-  "BlockSuiteEditor.saving": "Saving..."
+  "BlockSuiteEditor.saving": "Saving...",
+  "BlockSuiteEditor.pending": "Unsaved changes...",
+  "BlockSuiteEditor.saved": "Saved",
+  "BlockSuiteEditor.saveError": "Save failed"
 }

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -533,5 +533,8 @@
   "RHSBoardCards.no-cards": "No cards in this board.",
   "BoardMessage.linkBoard": "@{username} linked the board [{boardTitle}]({boardLink}) with this channel",
   "BoardMessage.unlinkBoard": "@{username} unlinked the board [{boardTitle}]({boardLink}) with this channel",
-  "BoardMessage.cardNotify": "@{username} notified about card [{cardTitle}]({cardLink}) in board [{boardTitle}]({boardLink})"
+  "BoardMessage.cardNotify": "@{username} notified about card [{cardTitle}]({cardLink}) in board [{boardTitle}]({boardLink})",
+  "BlockSuiteEditor.loading": "Loading editor...",
+  "BlockSuiteEditor.error": "Failed to load editor",
+  "BlockSuiteEditor.saving": "Saving..."
 }

--- a/webapp/i18n/ko.json
+++ b/webapp/i18n/ko.json
@@ -532,5 +532,8 @@
   "RHSBoardCards.no-cards": "이 보드에는 카드가 없습니다.",
   "BoardMessage.linkBoard": "@{username}님이 보드 [{boardTitle}]({boardLink})을(를) 이 채널에 연결했습니다",
   "BoardMessage.unlinkBoard": "@{username}님이 보드 [{boardTitle}]({boardLink})을(를) 이 채널에서 연결 해제했습니다",
-  "BoardMessage.cardNotify": "@{username}님이 보드 [{boardTitle}]({boardLink})의 카드 [{cardTitle}]({cardLink})에 대해 알림을 보냈습니다"
+  "BoardMessage.cardNotify": "@{username}님이 보드 [{boardTitle}]({boardLink})의 카드 [{cardTitle}]({cardLink})에 대해 알림을 보냈습니다",
+  "BlockSuiteEditor.loading": "에디터를 불러오는 중...",
+  "BlockSuiteEditor.error": "에디터를 불러오지 못했습니다",
+  "BlockSuiteEditor.saving": "저장 중..."
 }

--- a/webapp/i18n/ko.json
+++ b/webapp/i18n/ko.json
@@ -535,5 +535,8 @@
   "BoardMessage.cardNotify": "@{username}님이 보드 [{boardTitle}]({boardLink})의 카드 [{cardTitle}]({cardLink})에 대해 알림을 보냈습니다",
   "BlockSuiteEditor.loading": "에디터를 불러오는 중...",
   "BlockSuiteEditor.error": "에디터를 불러오지 못했습니다",
-  "BlockSuiteEditor.saving": "저장 중..."
+  "BlockSuiteEditor.saving": "저장 중...",
+  "BlockSuiteEditor.pending": "저장되지 않은 변경사항...",
+  "BlockSuiteEditor.saved": "저장됨",
+  "BlockSuiteEditor.saveError": "저장 실패"
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9,9 +9,8 @@
 			"version": "9.0.0",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@blocksuite/blocks": "^0.0.0-canary-20250316001624",
-				"@blocksuite/presets": "^0.0.0-canary-20250316001624",
-				"@blocksuite/store": "^0.0.0-canary-20250316001624",
+				"@blocksuite/blocks": "^0.17.33",
+				"@blocksuite/presets": "^0.17.33",
 				"@draft-js-plugins/editor": "^4.1.2",
 				"@draft-js-plugins/emoji": "^4.6.0",
 				"@draft-js-plugins/mention": "^5.1.2",
@@ -23,7 +22,6 @@
 				"@mattermost/desktop-api": "5.10.0-2",
 				"@reduxjs/toolkit": "^1.8.0",
 				"@tippyjs/react": "4.2.6",
-				"@toeverything/theme": "^1.1.23",
 				"@types/react-custom-scrollbars": "^4.0.13",
 				"color": "^4.2.1",
 				"draft-js": "^0.11.7",
@@ -49,12 +47,11 @@
 				"react-redux": "7.2.4",
 				"react-router-dom": "5.3.4",
 				"react-select": "^5.2.2",
-				"yjs": "^13.6.29"
+				"yjs": "^13.6.28"
 			},
 			"devDependencies": {
 				"@formatjs/cli": "^4.8.2",
 				"@formatjs/ts-transformer": "^3.9.2",
-				"@swc/core": "^1.15.8",
 				"@swc/jest": "^0.2.20",
 				"@testing-library/cypress": "^8.0.2",
 				"@testing-library/dom": "^8.11.4",
@@ -95,7 +92,6 @@
 				"eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#23abcf9988f7fa00d26929f11841aab7ccb16b2b",
 				"eslint-plugin-no-only-tests": "2.6.0",
 				"eslint-plugin-react": "7.29.4",
-				"eslint-plugin-react-hooks": "^7.0.1",
 				"fetch-mock-jest": "^1.5.1",
 				"file-loader": "^6.2.0",
 				"html-webpack-plugin": "^5.5.0",
@@ -105,7 +101,7 @@
 				"jest-mock": "27.5.1",
 				"prettier": "^2.6.1",
 				"redux-mock-store": "^1.5.4",
-				"sass": "^1.97.2",
+				"sass": "^1.49.9",
 				"sass-loader": "^12.6.0",
 				"start-server-and-test": "^1.14.0",
 				"style-loader": "^3.3.1",
@@ -114,7 +110,7 @@
 				"terser-webpack-plugin": "^5.3.1",
 				"ts-jest": "^27.1.4",
 				"ts-loader": "^9.2.8",
-				"typescript": "^5.9.3",
+				"typescript": "^4.6.3",
 				"webpack": "^5.70.0",
 				"webpack-cli": "^4.9.2",
 				"webpack-dev-server": "^4.11.1",
@@ -644,91 +640,89 @@
 			"license": "MIT"
 		},
 		"node_modules/@blocksuite/affine-block-embed": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-embed/-/affine-block-embed-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-u7IJu/qV3n3WqjbnVkwm/z1Q9NnEBBoSc+9qIe3P9ToEnscrvX9bSuMlCIsODZY4iMbGftYKF47spwzAQXSTxQ==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-embed/-/affine-block-embed-0.17.33.tgz",
+			"integrity": "sha512-VJG3SwWDYMoyn6FSRcMlh0CilYPjZM29QzW3IEkt6KqZ6pDghfPb+mnDhzzWpJLTHLlzMaIOn6qZBbasAFWIZg==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-block-surface": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/icons": "^2.1.75",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-block-surface": "0.17.33",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/icons": "^2.1.70",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0",
 				"minimatch": "^10.0.1",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/affine-block-list": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-list/-/affine-block-list-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-cvHeS9WehkWOyi5eC3v+z3fqqHguaoHqM403P5e4qanXk7a3jhIREbLFqvlC7KCqe1dy06rP8eS6CpTHMDGHJg==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-list/-/affine-block-list-0.17.33.tgz",
+			"integrity": "sha512-9FMLic6KhKBTMufzwUuPiZOCMXxbL3VhRIwQ6gvXI6xxc0IpTRNNhjjwXdKYgnCYh2HNLIi8kETisXyayc6Xvw==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
-				"@types/mdast": "^4.0.4",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0",
 				"minimatch": "^10.0.1",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/affine-block-paragraph": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-paragraph/-/affine-block-paragraph-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-9dLiFcNi5NXTpCXzfE7gv7XMKDhu/vrxYah/Csb8VY3XtMA2hAhQ4R57+qwUNVPkz9D6iKyBky+zSSPOPkJzRA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-paragraph/-/affine-block-paragraph-0.17.33.tgz",
+			"integrity": "sha512-kVVQBGRLtlXWPumbj34SLDQFGbbAZsf8YTTL/heCqWLJDPiyBZKmXBJKBY4U01wsn5qC4tMDyxneP2DJ1f0L7w==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
-				"@types/mdast": "^4.0.4",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0",
 				"minimatch": "^10.0.1",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/affine-block-surface": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-surface/-/affine-block-surface-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-Aqd8TgIIifeU+U13z6DNiTL+etSDfDw/2sgmLCiJ8JfG3y2rwEmd2IHYGgy6gkcvgHqggCgc9qHAXcaR2bFLPA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-block-surface/-/affine-block-surface-0.17.33.tgz",
+			"integrity": "sha512-eAu6l7eNSBAu2ppGzzmcGO9YrBEEiHoBBUy40D9kJzYN95xGO7r+VhONGxUdsjQ8+oxziVZgGdlc6bOKpjXeJw==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"fractional-indexing": "^3.2.0",
 				"lit": "^3.2.0",
 				"lodash.chunk": "^4.2.0",
@@ -737,23 +731,23 @@
 			}
 		},
 		"node_modules/@blocksuite/affine-components": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-components/-/affine-components-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-XJv6Tx0V/Nxaf1EFxwkviwLQvhLzSTeFRRbcpFDAN+seqlTpTkli+Efyan4RU5zbvVZapJsnNntQqvTfC7TWMg==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-components/-/affine-components-0.17.33.tgz",
+			"integrity": "sha512-+1wMuxReghQ8S+ffsMxzK27mCQTxcgPFkwVFrwgpXnbjMOCGesawNqwjvtpx/RS5PniAkujBnqtgspFhHp/2Jg==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/icons": "^2.1.75",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/icons": "^2.1.70",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
-				"@lottiefiles/dotlottie-wc": "^0.4.0",
+				"@lottiefiles/dotlottie-wc": "^0.2.16",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"date-fns": "^4.0.0",
 				"katex": "^0.16.11",
 				"lit": "^3.2.0",
@@ -764,37 +758,34 @@
 			}
 		},
 		"node_modules/@blocksuite/affine-model": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-model/-/affine-model-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-pt9tKrr+v4bpGZueLfPuKcmAn3rvx4tX4tZQ6cjhCnTjrNyfIrL+LJxRdvYeBfO8px73KLzZ3eIgbzYmZ466rA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-model/-/affine-model-0.17.33.tgz",
+			"integrity": "sha512-oYHAXSA5NXCV3+89Y54XFupqURcdIpLmbdfTXqWwT3EgQuwunuXynbjwwPxHpCOf77nKr5eu1pdSnO+N/c/WqQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"fractional-indexing": "^3.2.0",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/affine-shared": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-shared/-/affine-shared-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-u9FIzrHdqIORApSs5G9t/5gXvaDIbO7H62fzPebJyHioIPKbahAZusgBqubesMAcskkckXZSQXhRj1xE6MYU8A==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-shared/-/affine-shared-0.17.33.tgz",
+			"integrity": "sha512-GzGRU4V7It8gonWeZpG+wKn3gdcJlyldkSznK6szYxu285ZhOld3mRtxPSsD5G1MnplYwBDOljsxbGUlrujNug==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/icons": "^2.1.75",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
-				"@types/hast": "^3.0.4",
-				"@types/mdast": "^4.0.4",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0",
 				"lodash.clonedeep": "^4.5.0",
 				"lodash.mergewith": "^4.6.2",
@@ -803,29 +794,29 @@
 			}
 		},
 		"node_modules/@blocksuite/affine-widget-scroll-anchoring": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/affine-widget-scroll-anchoring/-/affine-widget-scroll-anchoring-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-8zQa3UQP8CFiLZQuTsG1v9vb8jFQGgIK7LxzBew4uSvOQJfEm2ppRJbB7iqfv6AXt2kvnwW0dKPbYXEBTypXCA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/affine-widget-scroll-anchoring/-/affine-widget-scroll-anchoring-0.17.33.tgz",
+			"integrity": "sha512-irK3Bu86DcbSCq2gVUkJiqDIUpY5ix7GzH7XssdjqPXN3oQgGglaDO7TGHkeYo4yiTh49WEu6T64pOzrZTwK1Q==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0"
 			}
 		},
 		"node_modules/@blocksuite/block-std": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/block-std/-/block-std-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-A5vSerrTDunFWoegJBONrhgQN8B6RoigAGkXgXdd3hp6PlpndCLJRQPhfG+gHQZrSDI3h74/yocxvVF7/wQhiw==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/block-std/-/block-std-0.17.33.tgz",
+			"integrity": "sha512-Scjhl3Na2umY1gY2s50MJ8v3mrgiBJuXdQSRmYDKrZRlkYcZwVQuQwlnrR2HpGKDHixIVUSi3W+qRc04UlGo4g==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
 				"@types/hast": "^3.0.4",
@@ -840,29 +831,29 @@
 			}
 		},
 		"node_modules/@blocksuite/blocks": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/blocks/-/blocks-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-5c2kd9XYMNT6Z5zAf1kcsGoRsorNS+JT8ru7ITXjwHqHAATQfSKovve2Yt95oG7G7bRjcFNOaCTyT25E8CZseA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/blocks/-/blocks-0.17.33.tgz",
+			"integrity": "sha512-tQnKHb5GXvv8QijNHBNB+4HvXoLXvika0JIhddbSIrrJ0BUL7I0IzC9wRCeNuJ3VpWjQ62I9YKtKDSON89xkZA==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-block-embed": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-block-list": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-block-paragraph": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-block-surface": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-widget-scroll-anchoring": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/data-view": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/icons": "^2.1.75",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-block-embed": "0.17.33",
+				"@blocksuite/affine-block-list": "0.17.33",
+				"@blocksuite/affine-block-paragraph": "0.17.33",
+				"@blocksuite/affine-block-surface": "0.17.33",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/affine-widget-scroll-anchoring": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/data-view": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/icons": "^2.1.70",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"@types/hast": "^3.0.4",
 				"@types/mdast": "^4.0.4",
 				"collapse-white-space": "^2.1.0",
@@ -874,7 +865,6 @@
 				"html2canvas": "^1.4.1",
 				"katex": "^0.16.11",
 				"lit": "^3.2.0",
-				"lz-string": "^1.5.0",
 				"mdast-util-gfm-autolink-literal": "^2.0.1",
 				"mdast-util-gfm-strikethrough": "^2.0.0",
 				"mdast-util-gfm-table": "^2.0.0",
@@ -898,78 +888,32 @@
 				"zod": "^3.23.8"
 			}
 		},
-		"node_modules/@blocksuite/blocks/node_modules/file-type": {
-			"version": "19.6.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-			"integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
-			"license": "MIT",
-			"dependencies": {
-				"get-stream": "^9.0.1",
-				"strtok3": "^9.0.1",
-				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/@blocksuite/blocks/node_modules/get-stream": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-			"license": "MIT",
-			"dependencies": {
-				"@sec-ant/readable-stream": "^0.4.1",
-				"is-stream": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@blocksuite/blocks/node_modules/is-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@blocksuite/data-view": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/data-view/-/data-view-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-Z1de4ADF4QFDdioZxbYKO480lwJGx4+UBzNGiZTzyZR3g3EuGd2cWL3YF+vMMSqxqA6UEfcwo4YtDtKGjq56sw==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/data-view/-/data-view-0.17.33.tgz",
+			"integrity": "sha512-+ZgUlJ5sSdxV3lIP6cmxnn6SYUwfzgyPjpptIyCc6cifOpzEQnNb9YJ/fF+NeP+JA0Narmdyiw6EVD3mS7ZnLQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-components": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/icons": "^2.1.75",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-components": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/icons": "^2.1.70",
+				"@blocksuite/store": "0.17.33",
 				"@emotion/hash": "^0.9.2",
 				"@floating-ui/dom": "^1.6.10",
 				"@lit/context": "^1.1.2",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"date-fns": "^4.0.0",
 				"lit": "^3.2.0",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/global": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/global/-/global-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-D8QPq9UWUaJBoq3iPhClPEVDbrUfddiP1PM3S7+TaJqetAkxTQIDCxd1ckTVhLLbpxX5TOHReng8nUOZPtjK1Q==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/global/-/global-0.17.33.tgz",
+			"integrity": "sha512-SWx1Jg5MeFOcY5sxiBIgKf+n1XjsGCSrL7F0WLrgLQS/CJ0vnnq5RLcgquMF6mvICH9Rhrc2FtcCbAOufe1E6g==",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@preact/signals-core": "^1.8.0",
@@ -1002,12 +946,12 @@
 			}
 		},
 		"node_modules/@blocksuite/inline": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/inline/-/inline-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-SOg6o+jotlERc9w4FK0fZ0z8Bx924BReYP6xftduh38Atp5Te5GtonaxNg8fyYsyIpnWoQtu7Irkp7SUkA/4Lw==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/inline/-/inline-0.17.33.tgz",
+			"integrity": "sha512-ra6yWERiSceJMW2T6OFiycCI1HIyrHwcDfSr4TTu6qAQli/7gexH+dfblesif1x/goHUeckJp1UnbxpAOxrzQQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
+				"@blocksuite/global": "0.17.33",
 				"@preact/signals-core": "^1.8.0",
 				"zod": "^3.23.8"
 			},
@@ -1017,36 +961,36 @@
 			}
 		},
 		"node_modules/@blocksuite/presets": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/presets/-/presets-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-GiMupZMQtrobsZE7kPxTDKtlkUql4ausjY58J2UzRBTo5R+EEN7B1biji7tKWThSIHAuWPkG1r718cDyJRZhXQ==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/presets/-/presets-0.17.33.tgz",
+			"integrity": "sha512-HzWlD0uvWXZ5OUhTCAAFsBJDMDljZYHfa3HOclra8NXSwqU+qe2eMOTSiifNOBRpHZTbvWBLQXYWvxvJae8LHQ==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/affine-block-surface": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-model": "0.0.0-canary-20250316001624",
-				"@blocksuite/affine-shared": "0.0.0-canary-20250316001624",
-				"@blocksuite/block-std": "0.0.0-canary-20250316001624",
-				"@blocksuite/blocks": "0.0.0-canary-20250316001624",
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/store": "0.0.0-canary-20250316001624",
+				"@blocksuite/affine-block-surface": "0.17.33",
+				"@blocksuite/affine-model": "0.17.33",
+				"@blocksuite/affine-shared": "0.17.33",
+				"@blocksuite/block-std": "0.17.33",
+				"@blocksuite/blocks": "0.17.33",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/store": "0.17.33",
 				"@floating-ui/dom": "^1.6.10",
-				"@lottiefiles/dotlottie-wc": "^0.4.0",
+				"@lottiefiles/dotlottie-wc": "^0.2.16",
 				"@preact/signals-core": "^1.8.0",
-				"@toeverything/theme": "^1.1.1",
+				"@toeverything/theme": "^1.0.15",
 				"lit": "^3.2.0",
 				"zod": "^3.23.8"
 			}
 		},
 		"node_modules/@blocksuite/store": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/store/-/store-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-bJn3S9KoYUO7hWU6h0xHXYFKEROVMJZwd7hoU+jWxQ6IgwafLFzEKBcLkOD8FuHVuRlRsI2JFALSQ2QqO+BUmA==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/store/-/store-0.17.33.tgz",
+			"integrity": "sha512-YzrGp95Na2OIX4Y/ccvj7kTcr2YE5Ko9ya3FpBuzErX1qzsHplBbM5G1LUghE6p9R6qWaJV1jBZ2FnqJJXKBYw==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
-				"@blocksuite/inline": "0.0.0-canary-20250316001624",
-				"@blocksuite/sync": "0.0.0-canary-20250316001624",
+				"@blocksuite/global": "0.17.33",
+				"@blocksuite/inline": "0.17.33",
+				"@blocksuite/sync": "0.17.33",
 				"@preact/signals-core": "^1.8.0",
 				"@types/flexsearch": "^0.7.6",
 				"@types/lodash.ismatch": "^4.4.9",
@@ -1065,59 +1009,13 @@
 				"yjs": "^13.6.18"
 			}
 		},
-		"node_modules/@blocksuite/store/node_modules/file-type": {
-			"version": "19.6.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-			"integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
-			"license": "MIT",
-			"dependencies": {
-				"get-stream": "^9.0.1",
-				"strtok3": "^9.0.1",
-				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
-		"node_modules/@blocksuite/store/node_modules/get-stream": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-			"license": "MIT",
-			"dependencies": {
-				"@sec-ant/readable-stream": "^0.4.1",
-				"is-stream": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@blocksuite/store/node_modules/is-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@blocksuite/sync": {
-			"version": "0.0.0-canary-20250316001624",
-			"resolved": "https://registry.npmjs.org/@blocksuite/sync/-/sync-0.0.0-canary-20250316001624.tgz",
-			"integrity": "sha512-2rWOVWaJhjo07ij6/hnnPP8zksfwVLyLXgzGZQgvGZq8AbAQvG9SzEEqLd7UcU+l/3QxcSqteZq/v5QjHg203A==",
+			"version": "0.17.33",
+			"resolved": "https://registry.npmjs.org/@blocksuite/sync/-/sync-0.17.33.tgz",
+			"integrity": "sha512-4+FxN99+lNBWlK6j2D6R6v9Zhr2e9d0vfdMhQs3ytE3ourhnfbL7hNXVJgzpHYl8U8a3hWKYSvAm27U5unZzOA==",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@blocksuite/global": "0.0.0-canary-20250316001624",
+				"@blocksuite/global": "0.17.33",
 				"idb": "^8.0.0",
 				"idb-keyval": "^6.2.1",
 				"y-protocols": "^1.0.6"
@@ -1589,17 +1487,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1703,20 +1590,6 @@
 				"ts-jest": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@formatjs/cli/node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -1902,6 +1775,20 @@
 				"undici-types": "~6.21.0"
 			}
 		},
+		"node_modules/@formatjs/ts-transformer/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/@fullcalendar/common": {
 			"version": "5.11.5",
 			"resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.5.tgz",
@@ -1976,17 +1863,6 @@
 			},
 			"engines": {
 				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
@@ -2787,19 +2663,19 @@
 			}
 		},
 		"node_modules/@lottiefiles/dotlottie-wc": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-wc/-/dotlottie-wc-0.4.6.tgz",
-			"integrity": "sha512-H1z1m/cBOoaq2Sw9wc9fOhCFvhL5tmek66eV9Srtex5vnUuzv/BAb8ZFbjvFSlyKfhaWdCzboG4vtJxWAqOvPA==",
+			"version": "0.2.24",
+			"resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-wc/-/dotlottie-wc-0.2.24.tgz",
+			"integrity": "sha512-jJ6p3ZfKaZosfcwX0kf1PpsQvxhDYJlD0jjt2j8FGSW2jwRa/E13ln8H7GmwjD5dhLQJSexwushgPUxAlXdCmQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@lottiefiles/dotlottie-web": "0.41.0",
-				"lit": "^3.2.1"
+				"@lottiefiles/dotlottie-web": "0.36.1",
+				"lit": "^3.1.0"
 			}
 		},
 		"node_modules/@lottiefiles/dotlottie-web": {
-			"version": "0.41.0",
-			"resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.41.0.tgz",
-			"integrity": "sha512-hJR3zN9DiQkNjEA0+OJbuPJPXZtbySrfYa61WD5qFc7dBPHGDUaSC6APvwM2FSrzPy0AU4nrOPfExEe6VNznkg==",
+			"version": "0.36.1",
+			"resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.36.1.tgz",
+			"integrity": "sha512-KvxOH5Msk0Ivqpgq4p1DGo1IG2XPX4kEVkhssTaOUEvoeCxDLru+DlbUzwG8b5JcJwEBmrAMzCNzCTmn+uMFxQ==",
 			"license": "MIT"
 		},
 		"node_modules/@mattermost/client": {
@@ -3242,9 +3118,9 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
-			"integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.2.tgz",
+			"integrity": "sha512-5Yf8h1Ke3SMHr15xl630KtwPTW4sYDFkkxS0vQ8UiQLWwZQnrF9IKaVG1mN5VcJz52EcWs2acsc/Npjha/7ysA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3449,215 +3325,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"node_modules/@swc/core": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.8.tgz",
-			"integrity": "sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@swc/counter": "^0.1.3",
-				"@swc/types": "^0.1.25"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/swc"
-			},
-			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.15.8",
-				"@swc/core-darwin-x64": "1.15.8",
-				"@swc/core-linux-arm-gnueabihf": "1.15.8",
-				"@swc/core-linux-arm64-gnu": "1.15.8",
-				"@swc/core-linux-arm64-musl": "1.15.8",
-				"@swc/core-linux-x64-gnu": "1.15.8",
-				"@swc/core-linux-x64-musl": "1.15.8",
-				"@swc/core-win32-arm64-msvc": "1.15.8",
-				"@swc/core-win32-ia32-msvc": "1.15.8",
-				"@swc/core-win32-x64-msvc": "1.15.8"
-			},
-			"peerDependencies": {
-				"@swc/helpers": ">=0.5.17"
-			},
-			"peerDependenciesMeta": {
-				"@swc/helpers": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.8.tgz",
-			"integrity": "sha512-M9cK5GwyWWRkRGwwCbREuj6r8jKdES/haCZ3Xckgkl8MUQJZA3XB7IXXK1IXRNeLjg6m7cnoMICpXv1v1hlJOg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.8.tgz",
-			"integrity": "sha512-j47DasuOvXl80sKJHSi2X25l44CMc3VDhlJwA7oewC1nV1VsSzwX+KOwE5tLnfORvVJJyeiXgJORNYg4jeIjYQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.8.tgz",
-			"integrity": "sha512-siAzDENu2rUbwr9+fayWa26r5A9fol1iORG53HWxQL1J8ym4k7xt9eME0dMPXlYZDytK5r9sW8zEA10F2U3Xwg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.8.tgz",
-			"integrity": "sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.8.tgz",
-			"integrity": "sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.8.tgz",
-			"integrity": "sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.8.tgz",
-			"integrity": "sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.8.tgz",
-			"integrity": "sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.8.tgz",
-			"integrity": "sha512-/wfAgxORg2VBaUoFdytcVBVCgf1isWZIEXB9MZEUty4wwK93M/PxAkjifOho9RN3WrM3inPLabICRCEgdHpKKQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.15.8",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.8.tgz",
-			"integrity": "sha512-GpMePrh9Sl4d61o4KAHOOv5is5+zt6BEXCOCgs/H0FLGeii7j9bWDE8ExvKFy2GRRZVNR1ugsnzaGWHKM6kuzA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -3681,16 +3348,6 @@
 			},
 			"peerDependencies": {
 				"@swc/core": "*"
-			}
-		},
-		"node_modules/@swc/types": {
-			"version": "0.1.25",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
-			"integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@swc/counter": "^0.1.3"
 			}
 		},
 		"node_modules/@testing-library/cypress": {
@@ -6001,9 +5658,9 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6038,9 +5695,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.15",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
-			"integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+			"version": "2.9.17",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
+			"integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6897,6 +6554,24 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/brace-expansion/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
@@ -7852,9 +7527,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-			"integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -7863,9 +7538,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8489,9 +8164,9 @@
 			"license": "MIT"
 		},
 		"node_modules/decode-named-character-reference": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"character-entities": "^2.0.0"
@@ -9321,9 +8996,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.267",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+			"version": "1.5.277",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.277.tgz",
+			"integrity": "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9454,9 +9129,9 @@
 			}
 		},
 		"node_modules/entities": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-			"integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -9947,17 +9622,6 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
 			}
 		},
-		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10056,37 +9720,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-			}
-		},
-		"node_modules/eslint-plugin-react-hooks": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-			"integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.24.4",
-				"@babel/parser": "^7.24.4",
-				"hermes-parser": "^0.25.1",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-validation-error": "^3.5.0 || ^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -10205,17 +9838,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
@@ -11157,13 +10779,49 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "12.4.2",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-			"integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
-			"dev": true,
+			"version": "19.6.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
+			"integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"get-stream": "^9.0.1",
+				"strtok3": "^9.0.1",
+				"token-types": "^6.0.0",
+				"uint8array-extras": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/file-type/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/file-type/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/filename-reserved-regex": {
@@ -11787,17 +11445,6 @@
 			"dev": true,
 			"license": "BSD-2-Clause"
 		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -12293,23 +11940,6 @@
 			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
-			}
-		},
-		"node_modules/hermes-estree": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/hermes-parser": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hermes-estree": "0.25.1"
 			}
 		},
 		"node_modules/history": {
@@ -13109,6 +12739,16 @@
 			},
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/imagemin/node_modules/file-type": {
+			"version": "12.4.2",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+			"integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/imagemin/node_modules/globby": {
@@ -15992,15 +15632,15 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.chunk": {
@@ -20303,9 +19943,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.97.2",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
-			"integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
+			"version": "1.97.3",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20585,22 +20225,26 @@
 			}
 		},
 		"node_modules/serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+			"integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.8",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
+				"http-errors": "~1.8.0",
+				"mime-types": "~2.1.35",
+				"parseurl": "~1.3.3"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/serve-index/node_modules/debug": {
@@ -20624,27 +20268,21 @@
 			}
 		},
 		"node_modules/serve-index/node_modules/http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/serve-index/node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/ms": {
 			"version": "2.0.0",
@@ -20652,13 +20290,6 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/serve-index/node_modules/setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/statuses": {
 			"version": "1.5.0",
@@ -21770,13 +21401,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/stylelint/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/stylelint/node_modules/import-lazy": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -22111,17 +21735,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
@@ -22744,9 +22357,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -22754,7 +22367,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/ua-parser-js": {
@@ -22918,9 +22531,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -24117,19 +23730,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-validation-error": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/zwitch": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"description": "",
 	"scripts": {
+		"postinstall": "node scripts/patch-blocksuite.js",
 		"build": "webpack --mode=production",
 		"build:watch": "webpack --mode=production --watch",
 		"debug": "webpack --mode=development",
@@ -27,13 +28,11 @@
 		"cypress:run:firefox": "cypress run --browser firefox",
 		"cypress:run:edge": "cypress run --browser edge",
 		"cypress:run:electron": "cypress run --browser electron",
-		"cypress:open": "cypress open",
-		"postinstall": "node scripts/patch-blocksuite.js"
+		"cypress:open": "cypress open"
 	},
 	"dependencies": {
-		"@blocksuite/blocks": "^0.0.0-canary-20250316001624",
-		"@blocksuite/presets": "^0.0.0-canary-20250316001624",
-		"@blocksuite/store": "^0.0.0-canary-20250316001624",
+		"@blocksuite/blocks": "^0.17.33",
+		"@blocksuite/presets": "^0.17.33",
 		"@draft-js-plugins/editor": "^4.1.2",
 		"@draft-js-plugins/emoji": "^4.6.0",
 		"@draft-js-plugins/mention": "^5.1.2",
@@ -45,7 +44,6 @@
 		"@mattermost/desktop-api": "5.10.0-2",
 		"@reduxjs/toolkit": "^1.8.0",
 		"@tippyjs/react": "4.2.6",
-		"@toeverything/theme": "^1.1.23",
 		"@types/react-custom-scrollbars": "^4.0.13",
 		"color": "^4.2.1",
 		"draft-js": "^0.11.7",
@@ -71,32 +69,14 @@
 		"react-redux": "7.2.4",
 		"react-router-dom": "5.3.4",
 		"react-select": "^5.2.2",
-		"yjs": "^13.6.29"
+		"yjs": "^13.6.28"
 	},
 	"jest": {
 		"moduleNameMapper": {
 			"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
 			"\\.(scss|css)$": "<rootDir>/__mocks__/styleMock.js",
 			"^mattermost-redux/(.*)$": "<rootDir>/node_modules/mattermost-redux/lib/$1",
-			"^@mattermost/types/(.*)$": "<rootDir>/node_modules/@mattermost/types/lib/$1",
-			"^@blocksuite/global/(.*)$": "<rootDir>/node_modules/@blocksuite/global/dist/$1",
-			"^@blocksuite/affine-components/(.*)$": "<rootDir>/node_modules/@blocksuite/affine-components/dist/$1/index.js",
-			"^@blocksuite/affine-shared/(.*)$": "<rootDir>/node_modules/@blocksuite/affine-shared/dist/$1",
-			"^@blocksuite/block-std/(.*)$": "<rootDir>/node_modules/@blocksuite/block-std/dist/$1",
-			"^@toeverything/theme/(.*)$": "<rootDir>/node_modules/@toeverything/theme/dist/$1",
-			"^@blocksuite/icons/(.*)$": "<rootDir>/node_modules/@blocksuite/icons/dist/$1.js",
-			"^@blocksuite/data-view/view-presets$": "<rootDir>/node_modules/@blocksuite/data-view/dist/view-presets/index.js",
-			"^@blocksuite/data-view/property-presets$": "<rootDir>/node_modules/@blocksuite/data-view/dist/property-presets/index.js",
-			"^@blocksuite/data-view/property-pure-presets$": "<rootDir>/node_modules/@blocksuite/data-view/dist/property-presets/pure-index.js",
-			"^@blocksuite/data-view/widget-presets$": "<rootDir>/node_modules/@blocksuite/data-view/dist/widget-presets/index.js",
-			"^@blocksuite/([^/]+)/effects$": "<rootDir>/node_modules/@blocksuite/$1/dist/effects.js",
-			"^@blocksuite/([^/]+)/schemas$": "<rootDir>/node_modules/@blocksuite/$1/dist/schemas.js",
-			"^shiki$": "<rootDir>/__mocks__/shikiMock.js",
-			"^shiki/(.*)$": "<rootDir>/__mocks__/shikiMock.js",
-			"unist-util-visit-parents/do-not-use-color": "<rootDir>/__mocks__/fileMock.js",
-			"#minpath": "<rootDir>/node_modules/vfile/lib/minpath.js",
-			"#minproc": "<rootDir>/node_modules/vfile/lib/minproc.js",
-			"#minurl": "<rootDir>/node_modules/vfile/lib/minurl.js"
+			"^@mattermost/types/(.*)$": "<rootDir>/node_modules/@mattermost/types/lib/$1"
 		},
 		"globals": {
 			"ts-jest": {
@@ -104,14 +84,10 @@
 			}
 		},
 		"transform": {
-			"^.+\\.(t|j)sx?$": "@swc/jest"
+			"^.+\\.tsx?$": "@swc/jest"
 		},
 		"transformIgnorePatterns": [
-			"/node_modules/(?!(nanoevents|@blocksuite|@toeverything|lib0|y-protocols|nanoid|lit|@lit|lit-.*|rehype-.*|remark-.*|unified|micromark|micromark-.*|mdast-.*|hast-.*|unist-.*|vfile.*|bail|trough|zwitch|property-.*|space-.*|comma-.*|web-namespaces|ccount|escape-string-regexp|markdown-table|longest-streak|decode-named-character-reference|character-entities.*|character-reference-invalid|trim-lines|devlop|hastscript|html-void-elements|is-plain-obj|fractional-indexing|@lottiefiles|shiki|date-fns|stringify-entities|collapse-white-space)/)"
-		],
-		"testPathIgnorePatterns": [
-			"/node_modules/",
-			"/dist/"
+			"/nanoevents/"
 		],
 		"maxWorkers": "50%",
 		"testEnvironment": "jsdom",
@@ -122,15 +98,11 @@
 		],
 		"setupFiles": [
 			"./tests/setupFile.ts"
-		],
-		"snapshotSerializers": [
-			"./tests/litSnapshotSerializer.js"
 		]
 	},
 	"devDependencies": {
 		"@formatjs/cli": "^4.8.2",
 		"@formatjs/ts-transformer": "^3.9.2",
-		"@swc/core": "^1.15.8",
 		"@swc/jest": "^0.2.20",
 		"@testing-library/cypress": "^8.0.2",
 		"@testing-library/dom": "^8.11.4",
@@ -171,7 +143,6 @@
 		"eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#23abcf9988f7fa00d26929f11841aab7ccb16b2b",
 		"eslint-plugin-no-only-tests": "2.6.0",
 		"eslint-plugin-react": "7.29.4",
-		"eslint-plugin-react-hooks": "^7.0.1",
 		"fetch-mock-jest": "^1.5.1",
 		"file-loader": "^6.2.0",
 		"html-webpack-plugin": "^5.5.0",
@@ -181,7 +152,7 @@
 		"jest-mock": "27.5.1",
 		"prettier": "^2.6.1",
 		"redux-mock-store": "^1.5.4",
-		"sass": "^1.97.2",
+		"sass": "^1.49.9",
 		"sass-loader": "^12.6.0",
 		"start-server-and-test": "^1.14.0",
 		"style-loader": "^3.3.1",
@@ -190,7 +161,7 @@
 		"terser-webpack-plugin": "^5.3.1",
 		"ts-jest": "^27.1.4",
 		"ts-loader": "^9.2.8",
-		"typescript": "^5.9.3",
+		"typescript": "^4.6.3",
 		"webpack": "^5.70.0",
 		"webpack-cli": "^4.9.2",
 		"webpack-dev-server": "^4.11.1",

--- a/webapp/scripts/patch-blocksuite.js
+++ b/webapp/scripts/patch-blocksuite.js
@@ -1,101 +1,71 @@
-#!/usr/bin/env node
-// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
-/**
- * BlockSuite canary 버전 패치 스크립트
- * 
- * 이 스크립트는 npm install 후 자동으로 실행되어 BlockSuite 패키지의 버그를 수정합니다.
- * 
- * 패치 내용:
- * 1. @blocksuite/icons/lit: CheckBoxCkeckSolidIcon 오타 수정 (CheckBoxCheckSolidIcon alias 추가)
- * 2. @blocksuite/blocks: exports 필드에 require 조건 추가 (webpack 호환성)
- */
-
 const fs = require('fs');
 const path = require('path');
 
-const nodeModulesPath = path.join(__dirname, '..', 'node_modules');
+const nodeModules = path.join(__dirname, '..', 'node_modules');
 
-console.log('[patch-blocksuite] Starting BlockSuite patches...');
-
-// 1. @blocksuite/icons/lit 패치 - CheckBoxCkeckSolidIcon 오타 수정
-function patchIconsLit() {
-    const litMjsPath = path.join(nodeModulesPath, '@blocksuite', 'icons', 'dist', 'lit.mjs');
-    const litJsPath = path.join(nodeModulesPath, '@blocksuite', 'icons', 'dist', 'lit.js');
+function renameSrcFolder(pkgName) {
+    const srcPath = path.join(nodeModules, '@blocksuite', pkgName, 'src');
+    const destPath = path.join(nodeModules, '@blocksuite', pkgName, '_src');
     
-    const aliasLine = 'CheckBoxCheckSolid as CheckBoxCkeckSolidIcon';
-    
-    // lit.mjs 패치
-    if (fs.existsSync(litMjsPath)) {
-        let content = fs.readFileSync(litMjsPath, 'utf8');
-        if (!content.includes('CheckBoxCkeckSolidIcon')) {
-            // export 블록의 마지막 항목 뒤에 alias 추가
-            content = content.replace(
-                /ZoomUp as ZoomUpIcon\s*\n\};/,
-                `ZoomUp as ZoomUpIcon,\n  ${aliasLine}\n};`
-            );
-            fs.writeFileSync(litMjsPath, content);
-            console.log('[patch-blocksuite] Patched lit.mjs - added CheckBoxCkeckSolidIcon alias');
-        } else {
-            console.log('[patch-blocksuite] lit.mjs already patched');
-        }
-    }
-    
-    // lit.js 패치 (CommonJS)
-    if (fs.existsSync(litJsPath)) {
-        let content = fs.readFileSync(litJsPath, 'utf8');
-        const exportLine = 'exports.CheckBoxCkeckSolidIcon = CheckBoxCheckSolid;';
-        if (!content.includes('CheckBoxCkeckSolidIcon')) {
-            content += `\n// Alias for typo in BlockSuite canary version\n${exportLine}\n`;
-            fs.writeFileSync(litJsPath, content);
-            console.log('[patch-blocksuite] Patched lit.js - added CheckBoxCkeckSolidIcon export');
-        } else {
-            console.log('[patch-blocksuite] lit.js already patched');
-        }
+    if (fs.existsSync(srcPath) && !fs.existsSync(destPath)) {
+        fs.renameSync(srcPath, destPath);
+        console.log(`Renamed ${pkgName}/src to ${pkgName}/_src`);
     }
 }
 
-// 2. @blocksuite/blocks 및 @blocksuite/presets package.json 패치 - exports에 require 조건 추가
-function patchPackageJsonExports(packageName) {
-    const packageJsonPath = path.join(nodeModulesPath, '@blocksuite', packageName, 'package.json');
+function fixTypoInFile(filePath) {
+    if (!fs.existsSync(filePath)) return false;
     
-    if (fs.existsSync(packageJsonPath)) {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-        
-        // exports 필드가 있고, require 조건이 없는 경우 패치
-        if (pkg.exports && pkg.exports['.'] && !pkg.exports['.'].require) {
-            // 각 export entry에 require 조건 추가
-            for (const key of Object.keys(pkg.exports)) {
-                const entry = pkg.exports[key];
-                if (typeof entry === 'object') {
-                    const importPath = entry.import || entry.module;
-                    if (importPath && !entry.require) {
-                        entry.require = importPath;
-                        entry.default = importPath;
-                    }
-                }
-            }
-            
-            fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2));
-            console.log(`[patch-blocksuite] Patched @blocksuite/${packageName}/package.json - added require conditions`);
-        } else {
-            console.log(`[patch-blocksuite] @blocksuite/${packageName}/package.json already patched or not needed`);
+    let content = fs.readFileSync(filePath, 'utf8');
+    if (content.includes('CheckBoxCkeckSolidIcon')) {
+        content = content.replace(/CheckBoxCkeckSolidIcon/g, 'CheckBoxCheckSolidIcon');
+        fs.writeFileSync(filePath, content, 'utf8');
+        console.log(`Fixed typo in ${path.relative(nodeModules, filePath)}`);
+        return true;
+    }
+    return false;
+}
+
+function findAndFixTypos(dir) {
+    if (!fs.existsSync(dir)) return;
+    
+    const files = fs.readdirSync(dir, { withFileTypes: true });
+    for (const file of files) {
+        const fullPath = path.join(dir, file.name);
+        if (file.isDirectory() && !file.name.startsWith('_')) {
+            findAndFixTypos(fullPath);
+        } else if (file.name.endsWith('.js')) {
+            fixTypoInFile(fullPath);
         }
     }
 }
 
-function patchBlocksPackageJson() {
-    patchPackageJsonExports('blocks');
-    patchPackageJsonExports('presets');
+function fixConstTypeParameter(filePath) {
+    if (!fs.existsSync(filePath)) return false;
+    
+    let content = fs.readFileSync(filePath, 'utf8');
+    const pattern = /,\s*const\s+(\w+)\s+extends/g;
+    if (pattern.test(content)) {
+        content = content.replace(/,\s*const\s+(\w+)\s+extends/g, ', $1 extends');
+        fs.writeFileSync(filePath, content, 'utf8');
+        console.log(`Fixed const type parameter in ${path.relative(nodeModules, filePath)}`);
+        return true;
+    }
+    return false;
 }
 
-// 패치 실행
-try {
-    patchIconsLit();
-    patchBlocksPackageJson();
-    console.log('[patch-blocksuite] All patches applied successfully!');
-} catch (error) {
-    console.error('[patch-blocksuite] Error applying patches:', error);
-    process.exit(1);
+console.log('Patching BlockSuite packages...');
+
+['store', 'blocks', 'presets', 'affine-components', 'data-view'].forEach(pkg => {
+    renameSrcFolder(pkg);
+});
+
+const blocksuiteDir = path.join(nodeModules, '@blocksuite');
+if (fs.existsSync(blocksuiteDir)) {
+    findAndFixTypos(blocksuiteDir);
 }
+
+const containerDts = path.join(nodeModules, '@blocksuite/global/dist/di/container.d.ts');
+fixConstTypeParameter(containerDts);
+
+console.log('BlockSuite patching complete.');

--- a/webapp/src/components/AGENTS.md
+++ b/webapp/src/components/AGENTS.md
@@ -1,0 +1,115 @@
+# COMPONENTS
+
+## OVERVIEW
+
+118 component directories. Functional React + hooks. SCSS styling with BEM.
+
+## STRUCTURE
+
+```
+components/
+├── blockSuite/           # BlockSuite editor (Yjs)
+├── cardDetail/           # Card edit dialog (21 files)
+├── kanban/               # Kanban view + calculations
+├── table/                # Table view (20 files)
+├── sidebar/              # Navigation sidebar (20 files)
+├── viewHeader/           # View controls (36 files)
+├── shareBoard/           # Sharing UI (12 files)
+├── content/              # Content blocks (17 files)
+├── gallery/              # Gallery view
+├── blocksEditor/         # Legacy block editor (being replaced)
+└── ...                   # Other feature components
+```
+
+## KEY COMPONENTS
+
+| Directory | Entry | Purpose |
+|-----------|-------|---------|
+| `blockSuite/` | `BlockSuiteEditor.tsx` | Rich text editor (Yjs CRDT) |
+| `cardDetail/` | `cardDetail.tsx` | Card properties + content |
+| `kanban/` | `kanban.tsx` | Drag-drop Kanban board |
+| `table/` | `table.tsx` | Spreadsheet-like view |
+| `sidebar/` | `sidebar.tsx` | Board navigation |
+| `viewHeader/` | `viewHeader.tsx` | Filter, sort, group controls |
+
+## COMPONENT PATTERN
+
+```tsx
+import React, {useCallback} from 'react'
+import {useIntl} from 'react-intl'
+import {useAppSelector} from '../../store/hooks'
+
+import './myComponent.scss'
+
+type Props = {
+    id: string
+    onAction?: () => void
+}
+
+const MyComponent: React.FC<Props> = ({id, onAction}) => {
+    const intl = useIntl()
+    const data = useAppSelector(state => state.boards.boards[id])
+    
+    const handleClick = useCallback(() => {
+        onAction?.()
+    }, [onAction])
+    
+    return (
+        <div className='MyComponent'>
+            <div className='MyComponent__header'>
+                {intl.formatMessage({id: 'Component.title', defaultMessage: 'Title'})}
+            </div>
+        </div>
+    )
+}
+
+export default React.memo(MyComponent)
+```
+
+## SCSS PATTERN
+
+```scss
+.MyComponent {
+    display: flex;
+    color: var(--center-channel-color);
+    background: var(--center-channel-bg);
+    
+    &__header {
+        font-weight: 600;
+    }
+    
+    &__content {
+        padding: 8px;
+    }
+    
+    &--active {
+        border-color: var(--button-bg);
+    }
+}
+```
+
+## BLOCKSUITE EDITOR
+
+Located in `blockSuite/`:
+- `BlockSuiteEditor.tsx` - Entry, mounts editor
+- `EditorProvider.tsx` - State, auto-save (2s debounce)
+- `EditorContainer.tsx` - DOM mount, drag/drop
+- `editor/editor.ts` - Init logic
+- `editor/context.ts` - React context
+
+## ANTI-PATTERNS
+
+- Class components
+- Inline styles
+- Non-memoized event handlers
+- Direct DOM access
+- Importing from parent directories (`../../..`)
+
+## TESTS
+
+```bash
+npm run test -- components/cardDetail/
+npm run test -- --watch
+```
+
+Snapshots in `__snapshots__/` dirs.

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -1,33 +1,209 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react'
+import React, {useEffect, useRef} from 'react'
+import {useIntl} from 'react-intl'
 
-import '@toeverything/theme/style.css'
-import 'katex/dist/katex.min.css'
-import { Card } from '../../blocks/card'
+import {AffineSchemas} from '@blocksuite/blocks'
+import {Schema, DocCollection} from '@blocksuite/store'
+import {PageEditor} from '@blocksuite/presets'
 
-import { EditorProvider } from './EditorProvider'
-import { EditorContainer } from './EditorContainer'
+import {effects as presetsEffects} from '@blocksuite/presets/effects'
 
-interface Props {
-    card: Card;
-    boardId: string;
-    readOnly?: boolean;
+import {effects as blocksEffects} from '@blocksuite/blocks/effects'
+
+import {Block} from '../../blocks/block'
+import {Card} from '../../blocks/card'
+
+import {useBlockSuiteEditor} from './useBlockSuiteEditor'
+import {createFocalboardBlobSource} from './focalboardBlobSource'
+
+import './blockSuiteTheme.css'
+import './blockSuite.scss'
+
+
+presetsEffects()
+blocksEffects()
+
+type Props = {
+    card: Card
+    contents: Block[]
+    readonly: boolean
 }
 
-/**
- * BlockSuite 에디터 메인 컴포넌트
- * EditorProvider와 EditorContainer를 조합하여 사용
- */
-export const BlockSuiteEditor: React.FC<Props> = ({ 
-    card, 
-    boardId, 
-    readOnly = false 
-}) => {
+function BlockSuiteEditor(props: Props): JSX.Element {
+    const {card, contents, readonly} = props
+    const intl = useIntl()
+
+    const containerRef = useRef<HTMLDivElement>(null)
+    const editorRef = useRef<PageEditor | null>(null)
+    const collectionRef = useRef<DocCollection | null>(null)
+
+    const {doc, loading, error, saving} = useBlockSuiteEditor({
+        card,
+        contents,
+        readonly,
+    })
+
+    useEffect(() => {
+        if (!containerRef.current || !doc) {
+            return
+        }
+
+        if (editorRef.current) {
+            editorRef.current.remove()
+            editorRef.current = null
+        }
+
+        try {
+            const schema = new Schema().register(AffineSchemas)
+            const blobSource = createFocalboardBlobSource(card.boardId)
+            const collection = new DocCollection({
+                schema,
+                blobSources: {
+                    main: blobSource,
+                },
+            })
+            collection.meta.initialize()
+
+            const editorDoc = collection.createDoc()
+
+            editorDoc.load(() => {
+                const yBlocks = doc.getMap('blocks')
+                const yMeta = doc.getMap('meta')
+
+                const rootId = editorDoc.addBlock('affine:page', {
+                    title: new editorDoc.Text(yMeta.get('cardTitle') as string || ''),
+                })
+
+                editorDoc.addBlock('affine:surface', {}, rootId)
+                const noteId = editorDoc.addBlock('affine:note', {}, rootId)
+
+                const blockOrder = (yMeta.get('blockOrder') as string[]) || []
+
+                blockOrder.forEach((blockId: string) => {
+                    const yBlock = yBlocks.get(blockId) as Map<string, unknown> | undefined
+                    if (!yBlock) {
+                        return
+                    }
+
+                    const blockType = yBlock.get('type') as string
+                    const blockProps = yBlock.get('props') as Record<string, unknown> || {}
+                    const blockText = yBlock.get('text') as string || ''
+
+                    switch (blockType) {
+                    case 'affine:paragraph': {
+                        const paragraphType = (blockProps.type as string) || 'text'
+                        editorDoc.addBlock('affine:paragraph', {
+                            type: paragraphType as 'text' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'quote',
+                            text: new editorDoc.Text(blockText),
+                        }, noteId)
+                        break
+                    }
+                    case 'affine:list': {
+                        const listType = (blockProps.type as string) || 'bulleted'
+                        editorDoc.addBlock('affine:list', {
+                            type: listType as 'bulleted' | 'numbered' | 'todo' | 'toggle',
+                            text: new editorDoc.Text(blockText),
+                            checked: (blockProps.checked as boolean) || false,
+                        }, noteId)
+                        break
+                    }
+                    case 'affine:divider': {
+                        editorDoc.addBlock('affine:divider', {}, noteId)
+                        break
+                    }
+                    case 'affine:image': {
+                        editorDoc.addBlock('affine:image', {
+                            sourceId: (blockProps.sourceId as string) || '',
+                        }, noteId)
+                        break
+                    }
+                    default: {
+                        editorDoc.addBlock('affine:paragraph', {
+                            type: 'text' as const,
+                            text: new editorDoc.Text(blockText),
+                        }, noteId)
+                    }
+                    }
+                })
+
+                if (blockOrder.length === 0) {
+                    editorDoc.addBlock('affine:paragraph', {
+                        type: 'text' as const,
+                        text: new editorDoc.Text(''),
+                    }, noteId)
+                }
+            })
+
+            const editor = new PageEditor()
+            editor.doc = editorDoc
+
+            if (readonly) {
+                editor.setAttribute('readonly', 'true')
+            }
+
+            containerRef.current.innerHTML = ''
+            containerRef.current.appendChild(editor)
+
+            editorRef.current = editor
+            collectionRef.current = collection
+        } catch (err) {
+            console.error('BlockSuite editor initialization error:', err)
+        }
+
+        return () => {
+            if (editorRef.current) {
+                editorRef.current.remove()
+                editorRef.current = null
+            }
+        }
+    }, [doc, readonly])
+
+    if (loading) {
+        return (
+            <div className='BlockSuiteEditor BlockSuiteEditor--loading'>
+                <div className='BlockSuiteEditor__spinner'/>
+                <span>
+                    {intl.formatMessage({
+                        id: 'BlockSuiteEditor.loading',
+                        defaultMessage: 'Loading editor...',
+                    })}
+                </span>
+            </div>
+        )
+    }
+
+    if (error) {
+        return (
+            <div className='BlockSuiteEditor BlockSuiteEditor--error'>
+                <span>
+                    {intl.formatMessage({
+                        id: 'BlockSuiteEditor.error',
+                        defaultMessage: 'Failed to load editor',
+                    })}
+                </span>
+                <p>{error.message}</p>
+            </div>
+        )
+    }
+
     return (
-        <EditorProvider card={card} boardId={boardId} readOnly={readOnly}>
-            <EditorContainer boardId={boardId} readOnly={readOnly} />
-        </EditorProvider>
+        <div className='BlockSuiteEditor'>
+            {saving && (
+                <div className='BlockSuiteEditor__saving'>
+                    {intl.formatMessage({
+                        id: 'BlockSuiteEditor.saving',
+                        defaultMessage: 'Saving...',
+                    })}
+                </div>
+            )}
+            <div
+                ref={containerRef}
+                className='BlockSuiteEditor__container'
+            />
+        </div>
     )
 }
+
+export default React.memo(BlockSuiteEditor)

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -1,26 +1,25 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef} from 'react'
+import React, {useEffect, useRef, useCallback, useState} from 'react'
 import {useIntl} from 'react-intl'
 
 import {AffineSchemas} from '@blocksuite/blocks'
-import {Schema, DocCollection} from '@blocksuite/store'
+import {Schema, DocCollection, Job, type Doc} from '@blocksuite/store'
 import {PageEditor} from '@blocksuite/presets'
 
 import {effects as presetsEffects} from '@blocksuite/presets/effects'
-
 import {effects as blocksEffects} from '@blocksuite/blocks/effects'
 
 import {Block} from '../../blocks/block'
 import {Card} from '../../blocks/card'
+import {Utils} from '../../utils'
 
 import {useBlockSuiteEditor} from './useBlockSuiteEditor'
 import {createFocalboardBlobSource} from './focalboardBlobSource'
 
 import './blockSuiteTheme.css'
 import './blockSuite.scss'
-
 
 presetsEffects()
 blocksEffects()
@@ -35,18 +34,43 @@ function BlockSuiteEditor(props: Props): JSX.Element {
     const {card, contents, readonly} = props
     const intl = useIntl()
 
+    const [containerMounted, setContainerMounted] = useState(false)
     const containerRef = useRef<HTMLDivElement>(null)
     const editorRef = useRef<PageEditor | null>(null)
     const collectionRef = useRef<DocCollection | null>(null)
+    const jobRef = useRef<Job | null>(null)
+    const editorDocRef = useRef<Doc | null>(null)
 
-    const {doc, loading, error, saving} = useBlockSuiteEditor({
+    const {snapshot, loading, error, saveStatus, scheduleSave} = useBlockSuiteEditor({
         card,
         contents,
         readonly,
     })
 
+    const containerCallbackRef = useCallback((node: HTMLDivElement | null) => {
+        containerRef.current = node
+        setContainerMounted(!!node)
+    }, [])
+
+    const handleDocUpdate = useCallback(async () => {
+        if (readonly || !editorDocRef.current || !jobRef.current) {
+            return
+        }
+
+        try {
+            const docSnapshot = await jobRef.current.docToSnapshot(editorDocRef.current)
+            if (docSnapshot) {
+                scheduleSave(docSnapshot)
+            }
+        } catch (err) {
+            Utils.logError(`Failed to create snapshot: ${err}`)
+        }
+    }, [readonly, scheduleSave])
+
     useEffect(() => {
-        if (!containerRef.current || !doc) {
+        Utils.log(`BlockSuiteEditor useEffect: containerMounted=${containerMounted}, snapshot=${!!snapshot}`)
+
+        if (!containerMounted || !containerRef.current || !snapshot) {
             return
         }
 
@@ -55,110 +79,77 @@ function BlockSuiteEditor(props: Props): JSX.Element {
             editorRef.current = null
         }
 
-        try {
-            const schema = new Schema().register(AffineSchemas)
-            const blobSource = createFocalboardBlobSource(card.boardId)
-            const collection = new DocCollection({
-                schema,
-                blobSources: {
-                    main: blobSource,
-                },
-            })
-            collection.meta.initialize()
-
-            const editorDoc = collection.createDoc()
-
-            editorDoc.load(() => {
-                const yBlocks = doc.getMap('blocks')
-                const yMeta = doc.getMap('meta')
-
-                const rootId = editorDoc.addBlock('affine:page', {
-                    title: new editorDoc.Text(yMeta.get('cardTitle') as string || ''),
-                })
-
-                editorDoc.addBlock('affine:surface', {}, rootId)
-                const noteId = editorDoc.addBlock('affine:note', {}, rootId)
-
-                const blockOrder = (yMeta.get('blockOrder') as string[]) || []
-
-                blockOrder.forEach((blockId: string) => {
-                    const yBlock = yBlocks.get(blockId) as Map<string, unknown> | undefined
-                    if (!yBlock) {
-                        return
-                    }
-
-                    const blockType = yBlock.get('type') as string
-                    const blockProps = yBlock.get('props') as Record<string, unknown> || {}
-                    const blockText = yBlock.get('text') as string || ''
-
-                    switch (blockType) {
-                    case 'affine:paragraph': {
-                        const paragraphType = (blockProps.type as string) || 'text'
-                        editorDoc.addBlock('affine:paragraph', {
-                            type: paragraphType as 'text' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'quote',
-                            text: new editorDoc.Text(blockText),
-                        }, noteId)
-                        break
-                    }
-                    case 'affine:list': {
-                        const listType = (blockProps.type as string) || 'bulleted'
-                        editorDoc.addBlock('affine:list', {
-                            type: listType as 'bulleted' | 'numbered' | 'todo' | 'toggle',
-                            text: new editorDoc.Text(blockText),
-                            checked: (blockProps.checked as boolean) || false,
-                        }, noteId)
-                        break
-                    }
-                    case 'affine:divider': {
-                        editorDoc.addBlock('affine:divider', {}, noteId)
-                        break
-                    }
-                    case 'affine:image': {
-                        editorDoc.addBlock('affine:image', {
-                            sourceId: (blockProps.sourceId as string) || '',
-                        }, noteId)
-                        break
-                    }
-                    default: {
-                        editorDoc.addBlock('affine:paragraph', {
-                            type: 'text' as const,
-                            text: new editorDoc.Text(blockText),
-                        }, noteId)
-                    }
-                    }
-                })
-
-                if (blockOrder.length === 0) {
-                    editorDoc.addBlock('affine:paragraph', {
-                        type: 'text' as const,
-                        text: new editorDoc.Text(''),
-                    }, noteId)
-                }
-            })
-
-            const editor = new PageEditor()
-            editor.doc = editorDoc
-
-            if (readonly) {
-                editor.setAttribute('readonly', 'true')
+        async function initEditor() {
+            if (!containerRef.current || !snapshot) {
+                return
             }
 
-            containerRef.current.innerHTML = ''
-            containerRef.current.appendChild(editor)
+            try {
+                Utils.log('BlockSuiteEditor: Starting initialization...')
+                Utils.log(`BlockSuiteEditor: Snapshot type=${snapshot.type}, blocks flavour=${snapshot.blocks?.flavour}`)
 
-            editorRef.current = editor
-            collectionRef.current = collection
-        } catch (err) {
-            console.error('BlockSuite editor initialization error:', err)
+                const schema = new Schema().register(AffineSchemas)
+                const blobSource = createFocalboardBlobSource(card.boardId)
+                const collection = new DocCollection({
+                    schema,
+                    blobSources: {
+                        main: blobSource,
+                    },
+                })
+                collection.meta.initialize()
+
+                const job = new Job({collection})
+
+                Utils.log('BlockSuiteEditor: Calling snapshotToDoc...')
+                const editorDoc = await job.snapshotToDoc(snapshot)
+                if (!editorDoc) {
+                    throw new Error('Failed to load document from snapshot')
+                }
+                Utils.log(`BlockSuiteEditor: snapshotToDoc returned doc id=${editorDoc.id}`)
+
+                editorDoc.load()
+                Utils.log('BlockSuiteEditor: Doc loaded')
+
+                const editor = new PageEditor()
+                editor.doc = editorDoc
+
+                if (readonly) {
+                    editor.setAttribute('readonly', 'true')
+                }
+
+                containerRef.current.innerHTML = ''
+                containerRef.current.appendChild(editor)
+
+                editorRef.current = editor
+                collectionRef.current = collection
+                jobRef.current = job
+                editorDocRef.current = editorDoc
+
+                if (!readonly && editorDoc.spaceDoc) {
+                    editorDoc.spaceDoc.on('update', handleDocUpdate)
+                }
+
+                Utils.log('BlockSuiteEditor: Initialization complete')
+            } catch (err) {
+                Utils.logError(`BlockSuite editor initialization error: ${err}`)
+                console.error('BlockSuite init error details:', err)
+            }
         }
 
+        initEditor()
+
         return () => {
+            if (editorDocRef.current?.spaceDoc) {
+                editorDocRef.current.spaceDoc.off('update', handleDocUpdate)
+            }
             if (editorRef.current) {
                 editorRef.current.remove()
                 editorRef.current = null
             }
+            editorDocRef.current = null
+            jobRef.current = null
         }
-    }, [doc, readonly])
+    }, [containerMounted, snapshot, readonly, card.boardId, handleDocUpdate])
 
     if (loading) {
         return (
@@ -188,18 +179,44 @@ function BlockSuiteEditor(props: Props): JSX.Element {
         )
     }
 
+    const getSaveStatusMessage = () => {
+        switch (saveStatus) {
+        case 'pending':
+            return intl.formatMessage({
+                id: 'BlockSuiteEditor.pending',
+                defaultMessage: 'Unsaved changes...',
+            })
+        case 'saving':
+            return intl.formatMessage({
+                id: 'BlockSuiteEditor.saving',
+                defaultMessage: 'Saving...',
+            })
+        case 'saved':
+            return intl.formatMessage({
+                id: 'BlockSuiteEditor.saved',
+                defaultMessage: 'Saved',
+            })
+        case 'error':
+            return intl.formatMessage({
+                id: 'BlockSuiteEditor.saveError',
+                defaultMessage: 'Save failed',
+            })
+        default:
+            return null
+        }
+    }
+
+    const statusMessage = getSaveStatusMessage()
+
     return (
         <div className='BlockSuiteEditor'>
-            {saving && (
-                <div className='BlockSuiteEditor__saving'>
-                    {intl.formatMessage({
-                        id: 'BlockSuiteEditor.saving',
-                        defaultMessage: 'Saving...',
-                    })}
+            {statusMessage && (
+                <div className={`BlockSuiteEditor__saving BlockSuiteEditor__saving--${saveStatus}`}>
+                    {statusMessage}
                 </div>
             )}
             <div
-                ref={containerRef}
+                ref={containerCallbackRef}
                 className='BlockSuiteEditor__container'
             />
         </div>

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -8,7 +8,9 @@ import {AffineSchemas} from '@blocksuite/blocks'
 import {Schema, DocCollection, Job, type Doc} from '@blocksuite/store'
 import {PageEditor} from '@blocksuite/presets'
 
+// @ts-expect-error - effects module has no type declarations
 import {effects as presetsEffects} from '@blocksuite/presets/effects'
+// @ts-expect-error - effects module has no type declarations
 import {effects as blocksEffects} from '@blocksuite/blocks/effects'
 
 import {Block} from '../../blocks/block'
@@ -36,7 +38,7 @@ function BlockSuiteEditor(props: Props): JSX.Element {
     const intl = useIntl()
 
     const [containerMounted, setContainerMounted] = useState(false)
-    const containerRef = useRef<HTMLDivElement>(null)
+    const containerRef = useRef<HTMLDivElement | null>(null)
     const editorRef = useRef<PageEditor | null>(null)
     const collectionRef = useRef<DocCollection | null>(null)
     const jobRef = useRef<Job | null>(null)

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -28,10 +28,11 @@ type Props = {
     card: Card
     contents: Block[]
     readonly: boolean
+    teamId: string
 }
 
 function BlockSuiteEditor(props: Props): JSX.Element {
-    const {card, contents, readonly} = props
+    const {card, contents, readonly, teamId} = props
     const intl = useIntl()
 
     const [containerMounted, setContainerMounted] = useState(false)
@@ -89,7 +90,7 @@ function BlockSuiteEditor(props: Props): JSX.Element {
                 Utils.log(`BlockSuiteEditor: Snapshot type=${snapshot.type}, blocks flavour=${snapshot.blocks?.flavour}`)
 
                 const schema = new Schema().register(AffineSchemas)
-                const blobSource = createFocalboardBlobSource(card.boardId)
+                const blobSource = createFocalboardBlobSource(card.boardId, teamId)
                 const collection = new DocCollection({
                     schema,
                     blobSources: {
@@ -149,7 +150,7 @@ function BlockSuiteEditor(props: Props): JSX.Element {
             editorDocRef.current = null
             jobRef.current = null
         }
-    }, [containerMounted, snapshot, readonly, card.boardId, handleDocUpdate])
+    }, [containerMounted, snapshot, readonly, card.boardId, teamId, handleDocUpdate])
 
     if (loading) {
         return (

--- a/webapp/src/components/blockSuite/blockSuite.scss
+++ b/webapp/src/components/blockSuite/blockSuite.scss
@@ -32,6 +32,24 @@
         background: rgba(255, 255, 255, 0.9);
         border-radius: 4px;
         z-index: 10;
+        transition: opacity 0.2s ease, background-color 0.2s ease;
+
+        &--pending {
+            color: rgba(0, 0, 0, 0.5);
+        }
+
+        &--saving {
+            color: var(--button-bg, #1c58d9);
+        }
+
+        &--saved {
+            color: var(--online-indicator, #3db887);
+        }
+
+        &--error {
+            color: var(--error-text, #dc2626);
+            background: rgba(220, 38, 38, 0.1);
+        }
     }
 
     &__spinner {

--- a/webapp/src/components/blockSuite/blockSuite.scss
+++ b/webapp/src/components/blockSuite/blockSuite.scss
@@ -8,6 +8,14 @@
         min-height: 200px;
         isolation: isolate;
 
+        &.light {
+            opacity: 1;
+        }
+
+        .affine-block-component.light {
+            opacity: 1;
+        }
+
         affine-editor-container,
         page-editor {
             width: 100%;
@@ -239,4 +247,18 @@
     to {
         transform: rotate(360deg);
     }
+}
+
+affine-link-popover,
+affine-slash-menu,
+affine-toolbar-widget,
+affine-format-bar-widget,
+affine-linked-doc-popover,
+embed-card-create-modal,
+editor-toolbar,
+blocksuite-portal,
+affine-mobile-toolbar,
+[data-blocksuite-overlay],
+[data-affine-overlay] {
+    z-index: 1001 !important;
 }

--- a/webapp/src/components/blockSuite/blockSuite.scss
+++ b/webapp/src/components/blockSuite/blockSuite.scss
@@ -1,0 +1,224 @@
+.BlockSuiteEditor {
+    width: 100%;
+    min-height: 200px;
+    position: relative;
+
+    &__container {
+        width: 100%;
+        min-height: 200px;
+        isolation: isolate;
+
+        affine-editor-container,
+        page-editor {
+            width: 100%;
+            min-height: 200px;
+            display: block;
+            color: #000000;
+        }
+
+        img {
+            max-width: 100%;
+            height: auto;
+        }
+    }
+
+    &__saving {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        padding: 4px 8px;
+        font-size: 12px;
+        color: rgba(0, 0, 0, 0.64);
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 4px;
+        z-index: 10;
+    }
+
+    &__spinner {
+        width: 24px;
+        height: 24px;
+        border: 2px solid rgba(0, 0, 0, 0.2);
+        border-top-color: var(--button-bg, #1c58d9);
+        border-radius: 50%;
+        animation: blocksuite-spin 0.8s linear infinite;
+        margin-bottom: 8px;
+    }
+
+    &--loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 200px;
+        color: rgba(0, 0, 0, 0.64);
+    }
+
+    &--error {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 200px;
+        padding: 16px;
+        color: var(--error-text, #dc2626);
+        text-align: center;
+
+        p {
+            margin-top: 8px;
+            font-size: 12px;
+            color: rgba(0, 0, 0, 0.64);
+        }
+    }
+}
+
+.focalboard-body .BlockSuiteEditor__container {
+    * {
+        outline: revert;
+    }
+
+    .affine-list-block__prefix {
+        color: #000000;
+    }
+
+    hr {
+        all: unset;
+        display: block;
+        width: 100%;
+        height: 1px;
+        border-top: 1px solid var(--affine-divider-color);
+        margin: 18px 0;
+    }
+
+    a {
+        color: var(--affine-link-color, #1e96eb);
+        text-decoration: underline;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    input,
+    textarea {
+        background: var(--affine-background-primary-color, #ffffff);
+        color: #000000;
+        border: 1px solid var(--affine-border-color, rgba(0, 0, 0, 0.1));
+        border-radius: var(--affine-popover-radius, 8px);
+        padding: 8px 12px;
+        font-size: var(--affine-font-base, 15px);
+        line-height: var(--affine-line-height, 1.6);
+
+        &:focus {
+            outline: 2px solid var(--affine-primary-color, #1e96eb);
+            outline-offset: -2px;
+        }
+
+        &::placeholder {
+            color: var(--affine-placeholder-color, rgba(0, 0, 0, 0.4));
+        }
+    }
+
+    button {
+        font-family: var(--affine-font-family, inherit);
+        font-size: var(--affine-font-base, 15px);
+    }
+
+    [contenteditable='true'] {
+        outline: none;
+        caret-color: var(--affine-primary-color, #1e96eb);
+    }
+
+    [contenteditable='true']:empty::before {
+        color: var(--affine-placeholder-color, rgba(0, 0, 0, 0.4));
+    }
+
+    code {
+        font-family: var(--affine-font-code-family, monospace);
+        background: var(--affine-background-code-block, rgba(0, 0, 0, 0.04));
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-size: 0.9em;
+    }
+
+    pre {
+        background: var(--affine-background-code-block, rgba(0, 0, 0, 0.04));
+        padding: 16px;
+        border-radius: 8px;
+        overflow-x: auto;
+
+        code {
+            background: transparent;
+            padding: 0;
+        }
+    }
+
+    blockquote {
+        border-left: 3px solid var(--affine-quote-color, rgba(0, 0, 0, 0.2));
+        padding-left: 16px;
+        margin: 8px 0;
+        color: var(--affine-text-secondary-color, rgba(0, 0, 0, 0.6));
+    }
+
+    ul,
+    ol {
+        padding-left: 24px;
+        margin: 8px 0;
+    }
+
+    li {
+        line-height: var(--affine-line-height, 1.6);
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-weight: 600;
+        line-height: 1.3;
+        margin: 16px 0 8px;
+        color: #000000;
+    }
+
+    h1 {
+        font-size: var(--affine-font-h-1, 28px);
+    }
+    h2 {
+        font-size: var(--affine-font-h-2, 26px);
+    }
+    h3 {
+        font-size: var(--affine-font-h-3, 24px);
+    }
+    h4 {
+        font-size: var(--affine-font-h-4, 22px);
+    }
+    h5 {
+        font-size: var(--affine-font-h-5, 20px);
+    }
+    h6 {
+        font-size: var(--affine-font-h-6, 18px);
+    }
+
+    p {
+        margin: var(--affine-paragraph-space, 8px) 0;
+        line-height: var(--affine-line-height, 1.6);
+    }
+
+    img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 4px;
+    }
+
+    ::selection {
+        background: var(--affine-primary-color, #1e96eb);
+        color: #ffffff;
+    }
+}
+
+@keyframes blocksuite-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/webapp/src/components/blockSuite/blockSuiteApi.ts
+++ b/webapp/src/components/blockSuite/blockSuiteApi.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {DocSnapshot} from '@blocksuite/store'
+
 import {Utils} from '../../utils'
 
 /**
@@ -27,8 +29,8 @@ interface SaveDocResponse {
  * BlockSuite API 클라이언트
  *
  * 백엔드 API 엔드포인트:
- * - GET  /cards/{cardId}/blocksuite/content - Yjs 바이너리 스냅샷 로드
- * - PUT  /cards/{cardId}/blocksuite/content - Yjs 바이너리 스냅샷 저장
+ * - GET  /cards/{cardId}/blocksuite/content - DocSnapshot JSON 로드
+ * - PUT  /cards/{cardId}/blocksuite/content - DocSnapshot JSON 저장
  * - GET  /cards/{cardId}/blocksuite/info    - 문서 메타데이터 조회
  * - DELETE /cards/{cardId}/blocksuite       - 문서 삭제
  */
@@ -43,10 +45,10 @@ class BlockSuiteApiClient {
         }
     }
 
-    private getBinaryHeaders(): Record<string, string> {
+    private getJsonHeaders(): Record<string, string> {
         return {
             ...this.getHeaders(),
-            'Content-Type': 'application/octet-stream',
+            'Content-Type': 'application/json',
         }
     }
 
@@ -81,11 +83,11 @@ class BlockSuiteApiClient {
     }
 
     /**
-     * BlockSuite 문서 Yjs 바이너리 스냅샷 로드
+     * BlockSuite 문서 DocSnapshot JSON 로드
      * @param cardId 카드 ID
-     * @returns Yjs 바이너리 데이터 또는 null (404인 경우)
+     * @returns DocSnapshot 또는 null (404인 경우)
      */
-    async getDocContent(cardId: string): Promise<Uint8Array | null> {
+    async getDocContent(cardId: string): Promise<DocSnapshot | null> {
         const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite/content`
 
         try {
@@ -103,8 +105,7 @@ class BlockSuiteApiClient {
                 throw new Error(`Failed to get doc content: ${response.status}`)
             }
 
-            const arrayBuffer = await response.arrayBuffer()
-            return new Uint8Array(arrayBuffer)
+            return await response.json() as DocSnapshot
         } catch (error) {
             Utils.logError(`BlockSuiteApi.getDocContent error: ${error}`)
             throw error
@@ -112,20 +113,20 @@ class BlockSuiteApiClient {
     }
 
     /**
-     * BlockSuite 문서 Yjs 바이너리 스냅샷 저장
+     * BlockSuite 문서 DocSnapshot JSON 저장
      * @param cardId 카드 ID
-     * @param snapshot Yjs 바이너리 스냅샷
+     * @param snapshot DocSnapshot JSON
      * @returns 저장된 문서 정보
      */
-    async saveDocContent(cardId: string, snapshot: Uint8Array): Promise<SaveDocResponse> {
+    async saveDocContent(cardId: string, snapshot: DocSnapshot): Promise<SaveDocResponse> {
         const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite/content`
 
         try {
             const response = await fetch(url, {
                 method: 'PUT',
                 credentials: 'include',
-                headers: this.getBinaryHeaders(),
-                body: snapshot as unknown as BodyInit,
+                headers: this.getJsonHeaders(),
+                body: JSON.stringify(snapshot),
             })
 
             if (!response.ok) {

--- a/webapp/src/components/blockSuite/blockSuiteApi.ts
+++ b/webapp/src/components/blockSuite/blockSuiteApi.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Utils} from '../../utils'
+
+/**
+ * BlockSuite 문서 메타데이터
+ */
+export interface BlockSuiteDocInfo {
+    cardId: string
+    size: number
+    version: number
+    createdAt: number
+    updatedAt: number
+}
+
+/**
+ * BlockSuite API 응답 타입
+ */
+interface SaveDocResponse {
+    cardId: string
+    size: number
+    version: number
+}
+
+/**
+ * BlockSuite API 클라이언트
+ *
+ * 백엔드 API 엔드포인트:
+ * - GET  /cards/{cardId}/blocksuite/content - Yjs 바이너리 스냅샷 로드
+ * - PUT  /cards/{cardId}/blocksuite/content - Yjs 바이너리 스냅샷 저장
+ * - GET  /cards/{cardId}/blocksuite/info    - 문서 메타데이터 조회
+ * - DELETE /cards/{cardId}/blocksuite       - 문서 삭제
+ */
+class BlockSuiteApiClient {
+    private getBaseURL(): string {
+        return Utils.getBaseURL(true).replace(/\/$/, '')
+    }
+
+    private getHeaders(): Record<string, string> {
+        return {
+            'X-Requested-With': 'XMLHttpRequest',
+        }
+    }
+
+    private getBinaryHeaders(): Record<string, string> {
+        return {
+            ...this.getHeaders(),
+            'Content-Type': 'application/octet-stream',
+        }
+    }
+
+    /**
+     * BlockSuite 문서 존재 여부 및 메타데이터 확인
+     * @param cardId 카드 ID
+     * @returns 문서 정보 또는 null (404인 경우)
+     */
+    async getDocInfo(cardId: string): Promise<BlockSuiteDocInfo | null> {
+        const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite/info`
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                credentials: 'include',
+                headers: this.getHeaders(),
+            })
+
+            if (response.status === 404) {
+                return null
+            }
+
+            if (!response.ok) {
+                throw new Error(`Failed to get doc info: ${response.status}`)
+            }
+
+            return await response.json() as BlockSuiteDocInfo
+        } catch (error) {
+            Utils.logError(`BlockSuiteApi.getDocInfo error: ${error}`)
+            throw error
+        }
+    }
+
+    /**
+     * BlockSuite 문서 Yjs 바이너리 스냅샷 로드
+     * @param cardId 카드 ID
+     * @returns Yjs 바이너리 데이터 또는 null (404인 경우)
+     */
+    async getDocContent(cardId: string): Promise<Uint8Array | null> {
+        const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite/content`
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                credentials: 'include',
+                headers: this.getHeaders(),
+            })
+
+            if (response.status === 404) {
+                return null
+            }
+
+            if (!response.ok) {
+                throw new Error(`Failed to get doc content: ${response.status}`)
+            }
+
+            const arrayBuffer = await response.arrayBuffer()
+            return new Uint8Array(arrayBuffer)
+        } catch (error) {
+            Utils.logError(`BlockSuiteApi.getDocContent error: ${error}`)
+            throw error
+        }
+    }
+
+    /**
+     * BlockSuite 문서 Yjs 바이너리 스냅샷 저장
+     * @param cardId 카드 ID
+     * @param snapshot Yjs 바이너리 스냅샷
+     * @returns 저장된 문서 정보
+     */
+    async saveDocContent(cardId: string, snapshot: Uint8Array): Promise<SaveDocResponse> {
+        const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite/content`
+
+        try {
+            const response = await fetch(url, {
+                method: 'PUT',
+                credentials: 'include',
+                headers: this.getBinaryHeaders(),
+                body: snapshot as unknown as BodyInit,
+            })
+
+            if (!response.ok) {
+                throw new Error(`Failed to save doc content: ${response.status}`)
+            }
+
+            return await response.json() as SaveDocResponse
+        } catch (error) {
+            Utils.logError(`BlockSuiteApi.saveDocContent error: ${error}`)
+            throw error
+        }
+    }
+
+    /**
+     * BlockSuite 문서 삭제
+     * @param cardId 카드 ID
+     */
+    async deleteDoc(cardId: string): Promise<void> {
+        const url = `${this.getBaseURL()}/api/v2/cards/${encodeURIComponent(cardId)}/blocksuite`
+
+        try {
+            const response = await fetch(url, {
+                method: 'DELETE',
+                credentials: 'include',
+                headers: this.getHeaders(),
+            })
+
+            if (!response.ok && response.status !== 404) {
+                throw new Error(`Failed to delete doc: ${response.status}`)
+            }
+        } catch (error) {
+            Utils.logError(`BlockSuiteApi.deleteDoc error: ${error}`)
+            throw error
+        }
+    }
+}
+
+const blockSuiteApi = new BlockSuiteApiClient()
+export default blockSuiteApi
+export {BlockSuiteApiClient}

--- a/webapp/src/components/blockSuite/blockSuiteTheme.css
+++ b/webapp/src/components/blockSuite/blockSuiteTheme.css
@@ -1,1 +1,12 @@
 @import '@toeverything/theme/style.css';
+
+:root {
+    --affine-font-h-1: 28px;
+    --affine-font-h-2: 24px;
+    --affine-font-h-3: 20px;
+    --affine-font-h-4: 18px;
+    --affine-font-h-5: 16px;
+    --affine-font-h-6: 14px;
+    --affine-font-base: 15px;
+    --affine-line-height: 1.6;
+}

--- a/webapp/src/components/blockSuite/blockSuiteTheme.css
+++ b/webapp/src/components/blockSuite/blockSuiteTheme.css
@@ -9,4 +9,7 @@
     --affine-font-h-6: 14px;
     --affine-font-base: 15px;
     --affine-line-height: 1.6;
+    --affine-quote-color: rgba(0, 0, 0, 0.2);
+    --affine-black-30: rgba(0, 0, 0, 0.3);
+    --affine-paragraph-space: 8px;
 }

--- a/webapp/src/components/blockSuite/blockSuiteTheme.css
+++ b/webapp/src/components/blockSuite/blockSuiteTheme.css
@@ -1,0 +1,1 @@
+@import '@toeverything/theme/style.css';

--- a/webapp/src/components/blockSuite/focalboardBlobSource.ts
+++ b/webapp/src/components/blockSuite/focalboardBlobSource.ts
@@ -2,8 +2,78 @@
 // See LICENSE.txt for license information.
 
 import type {BlobSource} from '@blocksuite/sync'
+import type {DocSnapshot, BlockSnapshot} from '@blocksuite/store'
 
 import octoClient from '../../octoClient'
+import {Utils} from '../../utils'
+
+// Module-level maps persist across BlobSource instances
+// Key format: `${boardId}:${blobKey}` -> fileId
+const globalKeyToFileIdMap = new Map<string, string>()
+const globalBlobCache = new Map<string, Blob>()
+
+function makeGlobalKey(boardId: string, key: string): string {
+    return `${boardId}:${key}`
+}
+
+export function registerBlobMapping(boardId: string, key: string, fileId: string): void {
+    globalKeyToFileIdMap.set(makeGlobalKey(boardId, key), fileId)
+}
+
+export function getFileIdForKey(boardId: string, key: string): string | undefined {
+    return globalKeyToFileIdMap.get(makeGlobalKey(boardId, key))
+}
+
+export function getAllBlobMappings(boardId: string): Record<string, string> {
+    const result: Record<string, string> = {}
+    const prefix = `${boardId}:`
+    globalKeyToFileIdMap.forEach((fileId, globalKey) => {
+        if (globalKey.startsWith(prefix)) {
+            const key = globalKey.substring(prefix.length)
+            result[key] = fileId
+        }
+    })
+    return result
+}
+
+export function restoreBlobMappings(boardId: string, mappings: Record<string, string>): void {
+    for (const [key, fileId] of Object.entries(mappings)) {
+        registerBlobMapping(boardId, key, fileId)
+        Utils.log(`restoreBlobMappings: restored ${key} -> ${fileId}`)
+    }
+}
+
+interface ExtendedDocSnapshot extends DocSnapshot {
+    meta: DocSnapshot['meta'] & {
+        blobMap?: Record<string, string>
+    }
+}
+
+export function prepareSnapshotForSave(snapshot: DocSnapshot, boardId: string): DocSnapshot {
+    const blobMap = getAllBlobMappings(boardId)
+    if (Object.keys(blobMap).length === 0) {
+        return snapshot
+    }
+
+    Utils.log(`prepareSnapshotForSave: saving ${Object.keys(blobMap).length} blob mappings`)
+
+    const extended = snapshot as ExtendedDocSnapshot
+    return {
+        ...extended,
+        meta: {
+            ...extended.meta,
+            blobMap,
+        },
+    }
+}
+
+export function restoreSnapshotBlobMappings(snapshot: DocSnapshot, boardId: string): void {
+    const extended = snapshot as ExtendedDocSnapshot
+    if (extended.meta?.blobMap) {
+        Utils.log(`restoreSnapshotBlobMappings: found ${Object.keys(extended.meta.blobMap).length} mappings`)
+        restoreBlobMappings(boardId, extended.meta.blobMap)
+    }
+}
 
 export function createFocalboardBlobSource(boardId: string): BlobSource {
     return {
@@ -11,45 +81,94 @@ export function createFocalboardBlobSource(boardId: string): BlobSource {
         readonly: false,
 
         async get(key: string): Promise<Blob | null> {
+            Utils.log(`BlobSource.get called with key: ${key}`)
+
             if (!key) {
+                Utils.log('BlobSource.get: key is empty, returning null')
                 return null
             }
 
+            const globalKey = makeGlobalKey(boardId, key)
+            const cachedBlob = globalBlobCache.get(globalKey)
+            if (cachedBlob) {
+                Utils.log(`BlobSource.get: found blob in local cache, size=${cachedBlob.size}`)
+                return cachedBlob
+            }
+
             try {
-                const fileInfo = await octoClient.getFileAsDataUrl(boardId, key)
+                const fileId = globalKeyToFileIdMap.get(globalKey) || key
+
+                Utils.log(`BlobSource.get: fetching file from server, boardId=${boardId}, key=${key}, fileId=${fileId}`)
+                const fileInfo = await octoClient.getFileAsDataUrl(boardId, fileId)
+                Utils.log(`BlobSource.get: fileInfo=${JSON.stringify(fileInfo)}`)
+
                 if (!fileInfo?.url) {
+                    Utils.log('BlobSource.get: no url in fileInfo, returning null')
                     return null
                 }
 
                 const response = await fetch(fileInfo.url)
                 if (!response.ok) {
+                    Utils.log(`BlobSource.get: fetch failed with status ${response.status}`)
                     return null
                 }
 
-                return await response.blob()
+                const blob = await response.blob()
+                Utils.log(`BlobSource.get: successfully fetched blob, size=${blob.size}`)
+
+                globalBlobCache.set(globalKey, blob)
+
+                return blob
             } catch (err) {
+                Utils.logError(`BlobSource.get failed: ${err}`)
                 console.error('Failed to fetch blob:', key, err)
                 return null
             }
         },
 
         async set(key: string, value: Blob): Promise<string> {
+            Utils.log(`BlobSource.set called with key: ${key}, blob size: ${value.size}, type: ${value.type}`)
+
+            const globalKey = makeGlobalKey(boardId, key)
+            globalBlobCache.set(globalKey, value)
+            Utils.log(`BlobSource.set: stored blob in local cache with key=${key}`)
+
             try {
                 const file = new File([value], key, {type: value.type})
+                Utils.log(`BlobSource.set: uploading file to boardId=${boardId}`)
                 const fileId = await octoClient.uploadFile(boardId, file)
-                return fileId || key
+                Utils.log(`BlobSource.set: upload complete, fileId=${fileId}`)
+
+                if (fileId && fileId !== key) {
+                    globalKeyToFileIdMap.set(globalKey, fileId)
+                    Utils.log(`BlobSource.set: stored key->fileId mapping: ${key} -> ${fileId}`)
+                }
+
+                return key
             } catch (err) {
+                Utils.logError(`BlobSource.set failed: ${err}`)
                 console.error('Failed to upload blob:', err)
                 return key
             }
         },
 
         async delete(key: string): Promise<void> {
-            console.warn('Blob delete not implemented:', key)
+            Utils.log(`BlobSource.delete called with key: ${key}`)
+            const globalKey = makeGlobalKey(boardId, key)
+            globalBlobCache.delete(globalKey)
+            globalKeyToFileIdMap.delete(globalKey)
         },
 
         async list(): Promise<string[]> {
-            return []
+            Utils.log('BlobSource.list called')
+            const prefix = `${boardId}:`
+            const keys: string[] = []
+            globalBlobCache.forEach((_, k) => {
+                if (k.startsWith(prefix)) {
+                    keys.push(k.substring(prefix.length))
+                }
+            })
+            return keys
         },
     }
 }

--- a/webapp/src/components/blockSuite/focalboardBlobSource.ts
+++ b/webapp/src/components/blockSuite/focalboardBlobSource.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {BlobSource} from '@blocksuite/sync'
+
+import octoClient from '../../octoClient'
+
+export function createFocalboardBlobSource(boardId: string): BlobSource {
+    return {
+        name: 'focalboard',
+        readonly: false,
+
+        async get(key: string): Promise<Blob | null> {
+            if (!key) {
+                return null
+            }
+
+            try {
+                const fileInfo = await octoClient.getFileAsDataUrl(boardId, key)
+                if (!fileInfo?.url) {
+                    return null
+                }
+
+                const response = await fetch(fileInfo.url)
+                if (!response.ok) {
+                    return null
+                }
+
+                return await response.blob()
+            } catch (err) {
+                console.error('Failed to fetch blob:', key, err)
+                return null
+            }
+        },
+
+        async set(key: string, value: Blob): Promise<string> {
+            try {
+                const file = new File([value], key, {type: value.type})
+                const fileId = await octoClient.uploadFile(boardId, file)
+                return fileId || key
+            } catch (err) {
+                console.error('Failed to upload blob:', err)
+                return key
+            }
+        },
+
+        async delete(key: string): Promise<void> {
+            console.warn('Blob delete not implemented:', key)
+        },
+
+        async list(): Promise<string[]> {
+            return []
+        },
+    }
+}

--- a/webapp/src/components/blockSuite/focalboardBlobSource.ts
+++ b/webapp/src/components/blockSuite/focalboardBlobSource.ts
@@ -27,7 +27,9 @@ export function getFileIdForKey(boardId: string, key: string): string | undefine
 export function getAllBlobMappings(boardId: string): Record<string, string> {
     const result: Record<string, string> = {}
     const prefix = `${boardId}:`
+    Utils.log(`getAllBlobMappings: boardId=${boardId}, globalMap size=${globalKeyToFileIdMap.size}`)
     globalKeyToFileIdMap.forEach((fileId, globalKey) => {
+        Utils.log(`getAllBlobMappings: checking ${globalKey}`)
         if (globalKey.startsWith(prefix)) {
             const key = globalKey.substring(prefix.length)
             result[key] = fileId
@@ -37,6 +39,7 @@ export function getAllBlobMappings(boardId: string): Record<string, string> {
 }
 
 export function restoreBlobMappings(boardId: string, mappings: Record<string, string>): void {
+    Utils.log(`restoreBlobMappings: boardId=${boardId}, mappings count=${Object.keys(mappings).length}`)
     for (const [key, fileId] of Object.entries(mappings)) {
         registerBlobMapping(boardId, key, fileId)
         Utils.log(`restoreBlobMappings: restored ${key} -> ${fileId}`)
@@ -56,6 +59,9 @@ export function prepareSnapshotForSave(snapshot: DocSnapshot, boardId: string): 
     }
 
     Utils.log(`prepareSnapshotForSave: saving ${Object.keys(blobMap).length} blob mappings`)
+    for (const [key, fileId] of Object.entries(blobMap)) {
+        Utils.log(`prepareSnapshotForSave: ${key} -> ${fileId}`)
+    }
 
     const extended = snapshot as ExtendedDocSnapshot
     return {
@@ -75,7 +81,7 @@ export function restoreSnapshotBlobMappings(snapshot: DocSnapshot, boardId: stri
     }
 }
 
-export function createFocalboardBlobSource(boardId: string): BlobSource {
+export function createFocalboardBlobSource(boardId: string, teamId: string): BlobSource {
     return {
         name: 'focalboard',
         readonly: false,
@@ -98,8 +104,8 @@ export function createFocalboardBlobSource(boardId: string): BlobSource {
             try {
                 const fileId = globalKeyToFileIdMap.get(globalKey) || key
 
-                Utils.log(`BlobSource.get: fetching file from server, boardId=${boardId}, key=${key}, fileId=${fileId}`)
-                const fileInfo = await octoClient.getFileAsDataUrl(boardId, fileId)
+                Utils.log(`BlobSource.get: fetching file from server, boardId=${boardId}, teamId=${teamId}, key=${key}, fileId=${fileId}`)
+                const fileInfo = await octoClient.getFileAsDataUrl(boardId, fileId, teamId)
                 Utils.log(`BlobSource.get: fileInfo=${JSON.stringify(fileInfo)}`)
 
                 if (!fileInfo?.url) {
@@ -141,7 +147,7 @@ export function createFocalboardBlobSource(boardId: string): BlobSource {
 
                 if (fileId && fileId !== key) {
                     globalKeyToFileIdMap.set(globalKey, fileId)
-                    Utils.log(`BlobSource.set: stored key->fileId mapping: ${key} -> ${fileId}`)
+                    Utils.log(`BlobSource.set: stored key->fileId mapping: globalKey=${globalKey}, key=${key} -> ${fileId}`)
                 }
 
                 return key

--- a/webapp/src/components/blockSuite/focalboardBlobSource.ts
+++ b/webapp/src/components/blockSuite/focalboardBlobSource.ts
@@ -52,10 +52,10 @@ interface ExtendedDocSnapshot extends DocSnapshot {
     }
 }
 
-export function prepareSnapshotForSave(snapshot: DocSnapshot, boardId: string): DocSnapshot {
+export function prepareSnapshotForSave(snapshot: DocSnapshot, boardId: string): ExtendedDocSnapshot {
     const blobMap = getAllBlobMappings(boardId)
     if (Object.keys(blobMap).length === 0) {
-        return snapshot
+        return snapshot as ExtendedDocSnapshot
     }
 
     Utils.log(`prepareSnapshotForSave: saving ${Object.keys(blobMap).length} blob mappings`)
@@ -64,13 +64,14 @@ export function prepareSnapshotForSave(snapshot: DocSnapshot, boardId: string): 
     }
 
     const extended = snapshot as ExtendedDocSnapshot
-    return {
+    const result: ExtendedDocSnapshot = {
         ...extended,
         meta: {
             ...extended.meta,
             blobMap,
         },
     }
+    return result
 }
 
 export function restoreSnapshotBlobMappings(snapshot: DocSnapshot, boardId: string): void {

--- a/webapp/src/components/blockSuite/index.ts
+++ b/webapp/src/components/blockSuite/index.ts
@@ -5,7 +5,7 @@ export {default as blockSuiteApi} from './blockSuiteApi'
 export type {BlockSuiteDocInfo} from './blockSuiteApi'
 
 export {
-    convertLegacyBlocksToYjsDoc,
-    createEmptyYjsDoc,
+    convertLegacyBlocksToDocSnapshot,
+    createEmptyDocSnapshot,
 } from './legacyConverter'
-export type {ConvertedBlock, BlockSuiteBlockType, BlockSuiteProps} from './legacyConverter'
+export type {BlockSuiteFlavour} from './legacyConverter'

--- a/webapp/src/components/blockSuite/index.ts
+++ b/webapp/src/components/blockSuite/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export {default as blockSuiteApi} from './blockSuiteApi'
+export type {BlockSuiteDocInfo} from './blockSuiteApi'
+
+export {
+    convertLegacyBlocksToYjsDoc,
+    createEmptyYjsDoc,
+} from './legacyConverter'
+export type {ConvertedBlock, BlockSuiteBlockType, BlockSuiteProps} from './legacyConverter'

--- a/webapp/src/components/blockSuite/legacyConverter.ts
+++ b/webapp/src/components/blockSuite/legacyConverter.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as Y from 'yjs'
+
+import {Block, ContentBlockTypes} from '../../blocks/block'
+import {Card} from '../../blocks/card'
+
+type BlockSuiteBlockType =
+    | 'affine:paragraph'
+    | 'affine:list'
+    | 'affine:divider'
+    | 'affine:image'
+    | 'affine:embed'
+    | 'affine:attachment'
+
+interface BlockSuiteProps {
+    type?: string
+    checked?: boolean
+    sourceId?: string
+    filename?: string
+    width?: number
+    height?: number
+    size?: number
+}
+
+interface ConvertedBlock {
+    id: string
+    type: BlockSuiteBlockType
+    originalType: ContentBlockTypes
+    props: BlockSuiteProps
+    text?: string
+    createdAt: number
+    updatedAt: number
+}
+
+const BLOCK_TYPE_MAP: Record<ContentBlockTypes, {type: BlockSuiteBlockType; props: BlockSuiteProps}> = {
+    'text': {type: 'affine:paragraph', props: {type: 'text'}},
+    'h1': {type: 'affine:paragraph', props: {type: 'h1'}},
+    'h2': {type: 'affine:paragraph', props: {type: 'h2'}},
+    'h3': {type: 'affine:paragraph', props: {type: 'h3'}},
+    'quote': {type: 'affine:paragraph', props: {type: 'quote'}},
+    'checkbox': {type: 'affine:list', props: {type: 'todo'}},
+    'list-item': {type: 'affine:list', props: {type: 'bulleted'}},
+    'divider': {type: 'affine:divider', props: {}},
+    'image': {type: 'affine:image', props: {}},
+    'video': {type: 'affine:embed', props: {type: 'video'}},
+    'attachment': {type: 'affine:attachment', props: {}},
+}
+
+function convertBlockToBlockSuite(block: Block): ConvertedBlock {
+    const blockType = block.type as ContentBlockTypes
+    const mapping = BLOCK_TYPE_MAP[blockType] || BLOCK_TYPE_MAP.text
+    const fields = block.fields || {}
+
+    const result: ConvertedBlock = {
+        id: block.id,
+        type: mapping.type,
+        originalType: blockType,
+        props: {...mapping.props},
+        createdAt: block.createAt || Date.now(),
+        updatedAt: block.updateAt || Date.now(),
+    }
+
+    switch (blockType) {
+    case 'text':
+    case 'h1':
+    case 'h2':
+    case 'h3':
+    case 'quote':
+        result.text = block.title || ''
+        break
+
+    case 'checkbox':
+        result.text = block.title || ''
+        result.props.checked = Boolean(fields.value)
+        break
+
+    case 'list-item':
+        result.text = block.title || ''
+        break
+
+    case 'divider':
+        break
+
+    case 'image':
+        result.props.sourceId = fields.fileId || ''
+        result.props.filename = fields.filename || 'image'
+        result.props.width = fields.width || 0
+        result.props.height = fields.height || 0
+        break
+
+    case 'video':
+        result.props.sourceId = fields.fileId || ''
+        result.props.filename = fields.filename || 'video'
+        break
+
+    case 'attachment':
+        result.props.sourceId = fields.fileId || ''
+        result.props.filename = fields.filename || 'file'
+        result.props.size = fields.size || 0
+        break
+
+    default:
+        result.text = block.title || ''
+    }
+
+    return result
+}
+
+function sortBlocksByContentOrder(blocks: Block[], contentOrder: Array<string | string[]>): Block[] {
+    const flatOrder = contentOrder.flatMap((item) =>
+        (Array.isArray(item) ? item : [item]),
+    )
+
+    return [...blocks].sort((a, b) => {
+        const aIndex = flatOrder.indexOf(a.id)
+        const bIndex = flatOrder.indexOf(b.id)
+        if (aIndex === -1 && bIndex === -1) {
+            return 0
+        }
+        if (aIndex === -1) {
+            return 1
+        }
+        if (bIndex === -1) {
+            return -1
+        }
+        return aIndex - bIndex
+    })
+}
+
+export function convertLegacyBlocksToYjsDoc(
+    blocks: Block[],
+    card: Card,
+): Y.Doc {
+    const yDoc = new Y.Doc()
+    const yBlocks = yDoc.getMap('blocks')
+    const yMeta = yDoc.getMap('meta')
+
+    const contentOrder = card.fields?.contentOrder || []
+    const sortedBlocks = sortBlocksByContentOrder(blocks, contentOrder)
+
+    const blockOrder = sortedBlocks.map((b) => b.id)
+    yMeta.set('blockOrder', blockOrder)
+    yMeta.set('cardId', card.id)
+    yMeta.set('cardTitle', card.title || '')
+
+    sortedBlocks.forEach((block) => {
+        const yBlock = new Y.Map()
+        const converted = convertBlockToBlockSuite(block)
+
+        yBlock.set('id', converted.id)
+        yBlock.set('type', converted.type)
+        yBlock.set('originalType', converted.originalType)
+        yBlock.set('props', converted.props)
+        yBlock.set('createdAt', converted.createdAt)
+        yBlock.set('updatedAt', converted.updatedAt)
+
+        if (converted.text !== undefined) {
+            yBlock.set('text', converted.text)
+        }
+
+        yBlocks.set(block.id, yBlock)
+    })
+
+    return yDoc
+}
+
+export function createEmptyYjsDoc(card: Card): Y.Doc {
+    const yDoc = new Y.Doc()
+    const yMeta = yDoc.getMap('meta')
+
+    yMeta.set('blockOrder', [])
+    yMeta.set('cardId', card.id)
+    yMeta.set('cardTitle', card.title || '')
+
+    return yDoc
+}
+
+export {convertBlockToBlockSuite, sortBlocksByContentOrder}
+export type {ConvertedBlock, BlockSuiteBlockType, BlockSuiteProps}

--- a/webapp/src/components/blockSuite/legacyConverter.ts
+++ b/webapp/src/components/blockSuite/legacyConverter.ts
@@ -7,6 +7,8 @@ import {Block, ContentBlockTypes} from '../../blocks/block'
 import {Card} from '../../blocks/card'
 import {Utils, IDType} from '../../utils'
 
+import {parseMarkdownToDelta} from './markdownToDelta'
+
 type BlockSuiteFlavour =
     | 'affine:page'
     | 'affine:surface'
@@ -51,7 +53,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             type: 'text',
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
         break
@@ -63,7 +65,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             type: blockType,
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
         break
@@ -73,7 +75,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             type: 'quote',
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
         break
@@ -84,7 +86,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             checked: Boolean(fields.value),
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
         break
@@ -94,7 +96,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             type: 'bulleted',
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
         break
@@ -127,7 +129,7 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
             type: 'text',
             text: {
                 '$blocksuite:internal:text$': true,
-                delta: block.title ? [{insert: block.title}] : [],
+                delta: block.title ? parseMarkdownToDelta(block.title) : [],
             },
         }
     }
@@ -218,7 +220,7 @@ export function convertLegacyBlocksToDocSnapshot(
         props: {
             title: {
                 '$blocksuite:internal:text$': true,
-                delta: card.title ? [{insert: card.title}] : [],
+                delta: card.title ? parseMarkdownToDelta(card.title) : [],
             },
         },
         children: [surfaceBlock, noteBlock],
@@ -287,7 +289,7 @@ export function createEmptyDocSnapshot(card: Card): DocSnapshot {
         props: {
             title: {
                 '$blocksuite:internal:text$': true,
-                delta: card.title ? [{insert: card.title}] : [],
+                delta: card.title ? parseMarkdownToDelta(card.title) : [],
             },
         },
         children: [surfaceBlock, noteBlock],
@@ -303,6 +305,113 @@ export function createEmptyDocSnapshot(card: Card): DocSnapshot {
         },
         blocks: pageBlock,
     }
+}
+
+export function convertLegacyBlocksToMarkdown(
+    blocks: Block[],
+    card: Card,
+): string {
+    const contentOrder = card.fields?.contentOrder || []
+    const sortedBlocks = sortBlocksByContentOrder(blocks, contentOrder)
+
+    const markdownParts: string[] = []
+
+    for (const block of sortedBlocks) {
+        const blockType = block.type as ContentBlockTypes
+        const fields = block.fields || {}
+        const title = block.title || ''
+
+        switch (blockType) {
+        case 'text':
+            markdownParts.push(title)
+            break
+
+        case 'h1':
+            markdownParts.push(`# ${title}`)
+            break
+
+        case 'h2':
+            markdownParts.push(`## ${title}`)
+            break
+
+        case 'h3':
+            markdownParts.push(`### ${title}`)
+            break
+
+        case 'quote':
+            markdownParts.push(title.split('\n').map((line) => `> ${line}`).join('\n'))
+            break
+
+        case 'checkbox':
+            markdownParts.push(`- [${fields.value ? 'x' : ' '}] ${title}`)
+            break
+
+        case 'list-item':
+            markdownParts.push(`- ${title}`)
+            break
+
+        case 'divider':
+            markdownParts.push('---')
+            break
+
+        case 'image':
+            if (fields.fileId) {
+                markdownParts.push(`![${title || 'image'}](${fields.fileId})`)
+            }
+            break
+
+        case 'video':
+        case 'attachment':
+            markdownParts.push(`[${blockType}: ${fields.filename || 'file'}]`)
+            break
+
+        default:
+            markdownParts.push(title)
+        }
+    }
+
+    return markdownParts.join('\n\n')
+}
+
+export function hasComplexMarkdown(blocks: Block[]): boolean {
+    const BLOCK_LEVEL_PATTERNS = [
+        /^#{1,6}\s/,
+        /^[-*+]\s/,
+        /^\d+\.\s/,
+        /^>\s/,
+        /^```/,
+    ]
+
+    const INLINE_PATTERNS = [
+        /\*\*.+?\*\*/,
+        /__.+?__/,
+        /\*[^*]+\*/,
+        /_[^_]+_/,
+        /~~.+?~~/,
+        /`.+?`/,
+        /\[.+?\]\(.+?\)/,
+    ]
+
+    for (const block of blocks) {
+        const title = block.title || ''
+
+        if (title.includes('\n')) {
+            return true
+        }
+
+        for (const pattern of BLOCK_LEVEL_PATTERNS) {
+            if (pattern.test(title)) {
+                return true
+            }
+        }
+
+        for (const pattern of INLINE_PATTERNS) {
+            if (pattern.test(title)) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 export {sortBlocksByContentOrder}

--- a/webapp/src/components/blockSuite/legacyConverter.ts
+++ b/webapp/src/components/blockSuite/legacyConverter.ts
@@ -35,6 +35,8 @@ function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
     const flavour = CONTENT_TYPE_TO_FLAVOUR[blockType] || 'affine:paragraph'
     const fields = block.fields || {}
 
+    Utils.log(`convertContentBlockToSnapshot: type=${blockType}, title=${block.title?.substring(0, 30)}`)
+
     const snapshot: BlockSnapshot = {
         type: 'block',
         id: block.id,

--- a/webapp/src/components/blockSuite/legacyConverter.ts
+++ b/webapp/src/components/blockSuite/legacyConverter.ts
@@ -1,111 +1,136 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as Y from 'yjs'
+import type {BlockSnapshot, DocSnapshot} from '@blocksuite/store'
 
 import {Block, ContentBlockTypes} from '../../blocks/block'
 import {Card} from '../../blocks/card'
+import {Utils, IDType} from '../../utils'
 
-type BlockSuiteBlockType =
+type BlockSuiteFlavour =
+    | 'affine:page'
+    | 'affine:surface'
+    | 'affine:note'
     | 'affine:paragraph'
     | 'affine:list'
     | 'affine:divider'
     | 'affine:image'
-    | 'affine:embed'
-    | 'affine:attachment'
 
-interface BlockSuiteProps {
-    type?: string
-    checked?: boolean
-    sourceId?: string
-    filename?: string
-    width?: number
-    height?: number
-    size?: number
+const CONTENT_TYPE_TO_FLAVOUR: Record<ContentBlockTypes, BlockSuiteFlavour> = {
+    'text': 'affine:paragraph',
+    'h1': 'affine:paragraph',
+    'h2': 'affine:paragraph',
+    'h3': 'affine:paragraph',
+    'quote': 'affine:paragraph',
+    'checkbox': 'affine:list',
+    'list-item': 'affine:list',
+    'divider': 'affine:divider',
+    'image': 'affine:image',
+    'video': 'affine:paragraph',
+    'attachment': 'affine:paragraph',
 }
 
-interface ConvertedBlock {
-    id: string
-    type: BlockSuiteBlockType
-    originalType: ContentBlockTypes
-    props: BlockSuiteProps
-    text?: string
-    createdAt: number
-    updatedAt: number
-}
-
-const BLOCK_TYPE_MAP: Record<ContentBlockTypes, {type: BlockSuiteBlockType; props: BlockSuiteProps}> = {
-    'text': {type: 'affine:paragraph', props: {type: 'text'}},
-    'h1': {type: 'affine:paragraph', props: {type: 'h1'}},
-    'h2': {type: 'affine:paragraph', props: {type: 'h2'}},
-    'h3': {type: 'affine:paragraph', props: {type: 'h3'}},
-    'quote': {type: 'affine:paragraph', props: {type: 'quote'}},
-    'checkbox': {type: 'affine:list', props: {type: 'todo'}},
-    'list-item': {type: 'affine:list', props: {type: 'bulleted'}},
-    'divider': {type: 'affine:divider', props: {}},
-    'image': {type: 'affine:image', props: {}},
-    'video': {type: 'affine:embed', props: {type: 'video'}},
-    'attachment': {type: 'affine:attachment', props: {}},
-}
-
-function convertBlockToBlockSuite(block: Block): ConvertedBlock {
+function convertContentBlockToSnapshot(block: Block): BlockSnapshot {
     const blockType = block.type as ContentBlockTypes
-    const mapping = BLOCK_TYPE_MAP[blockType] || BLOCK_TYPE_MAP.text
+    const flavour = CONTENT_TYPE_TO_FLAVOUR[blockType] || 'affine:paragraph'
     const fields = block.fields || {}
 
-    const result: ConvertedBlock = {
+    const snapshot: BlockSnapshot = {
+        type: 'block',
         id: block.id,
-        type: mapping.type,
-        originalType: blockType,
-        props: {...mapping.props},
-        createdAt: block.createAt || Date.now(),
-        updatedAt: block.updateAt || Date.now(),
+        flavour,
+        props: {},
+        children: [],
     }
 
     switch (blockType) {
     case 'text':
+        snapshot.props = {
+            type: 'text',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
+        break
+
     case 'h1':
     case 'h2':
     case 'h3':
+        snapshot.props = {
+            type: blockType,
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
+        break
+
     case 'quote':
-        result.text = block.title || ''
+        snapshot.props = {
+            type: 'quote',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
         break
 
     case 'checkbox':
-        result.text = block.title || ''
-        result.props.checked = Boolean(fields.value)
+        snapshot.props = {
+            type: 'todo',
+            checked: Boolean(fields.value),
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
         break
 
     case 'list-item':
-        result.text = block.title || ''
+        snapshot.props = {
+            type: 'bulleted',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
         break
 
     case 'divider':
+        snapshot.props = {}
         break
 
     case 'image':
-        result.props.sourceId = fields.fileId || ''
-        result.props.filename = fields.filename || 'image'
-        result.props.width = fields.width || 0
-        result.props.height = fields.height || 0
+        snapshot.props = {
+            sourceId: fields.fileId || '',
+            width: fields.width || 0,
+            height: fields.height || 0,
+        }
         break
 
     case 'video':
-        result.props.sourceId = fields.fileId || ''
-        result.props.filename = fields.filename || 'video'
-        break
-
     case 'attachment':
-        result.props.sourceId = fields.fileId || ''
-        result.props.filename = fields.filename || 'file'
-        result.props.size = fields.size || 0
+        snapshot.props = {
+            type: 'text',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: [{insert: `[${blockType}: ${fields.filename || 'file'}]`}],
+            },
+        }
         break
 
     default:
-        result.text = block.title || ''
+        snapshot.props = {
+            type: 'text',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: block.title ? [{insert: block.title}] : [],
+            },
+        }
     }
 
-    return result
+    return snapshot
 }
 
 function sortBlocksByContentOrder(blocks: Block[], contentOrder: Array<string | string[]>): Block[] {
@@ -129,53 +154,154 @@ function sortBlocksByContentOrder(blocks: Block[], contentOrder: Array<string | 
     })
 }
 
-export function convertLegacyBlocksToYjsDoc(
+export function convertLegacyBlocksToDocSnapshot(
     blocks: Block[],
     card: Card,
-): Y.Doc {
-    const yDoc = new Y.Doc()
-    const yBlocks = yDoc.getMap('blocks')
-    const yMeta = yDoc.getMap('meta')
-
+): DocSnapshot {
     const contentOrder = card.fields?.contentOrder || []
     const sortedBlocks = sortBlocksByContentOrder(blocks, contentOrder)
 
-    const blockOrder = sortedBlocks.map((b) => b.id)
-    yMeta.set('blockOrder', blockOrder)
-    yMeta.set('cardId', card.id)
-    yMeta.set('cardTitle', card.title || '')
+    const pageId = `page:${card.id}`
+    const surfaceId = Utils.createGuid(IDType.None)
+    const noteId = Utils.createGuid(IDType.None)
 
-    sortedBlocks.forEach((block) => {
-        const yBlock = new Y.Map()
-        const converted = convertBlockToBlockSuite(block)
+    const contentChildren = sortedBlocks.map((block) =>
+        convertContentBlockToSnapshot(block),
+    )
 
-        yBlock.set('id', converted.id)
-        yBlock.set('type', converted.type)
-        yBlock.set('originalType', converted.originalType)
-        yBlock.set('props', converted.props)
-        yBlock.set('createdAt', converted.createdAt)
-        yBlock.set('updatedAt', converted.updatedAt)
+    if (contentChildren.length === 0) {
+        contentChildren.push({
+            type: 'block',
+            id: Utils.createGuid(IDType.None),
+            flavour: 'affine:paragraph',
+            props: {
+                type: 'text',
+                text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [],
+                },
+            },
+            children: [],
+        })
+    }
 
-        if (converted.text !== undefined) {
-            yBlock.set('text', converted.text)
-        }
+    const noteBlock: BlockSnapshot = {
+        type: 'block',
+        id: noteId,
+        flavour: 'affine:note',
+        props: {
+            xywh: '[0,0,800,600]',
+            background: '--affine-background-secondary-color',
+            index: 'a0',
+            hidden: false,
+            displayMode: 'both',
+        },
+        children: contentChildren,
+    }
 
-        yBlocks.set(block.id, yBlock)
-    })
+    const surfaceBlock: BlockSnapshot = {
+        type: 'block',
+        id: surfaceId,
+        flavour: 'affine:surface',
+        props: {
+            elements: {},
+        },
+        children: [],
+    }
 
-    return yDoc
+    const pageBlock: BlockSnapshot = {
+        type: 'block',
+        id: pageId,
+        flavour: 'affine:page',
+        props: {
+            title: {
+                '$blocksuite:internal:text$': true,
+                delta: card.title ? [{insert: card.title}] : [],
+            },
+        },
+        children: [surfaceBlock, noteBlock],
+    }
+
+    return {
+        type: 'page',
+        meta: {
+            id: card.id,
+            title: card.title || '',
+            createDate: card.createAt || Date.now(),
+            tags: [],
+        },
+        blocks: pageBlock,
+    }
 }
 
-export function createEmptyYjsDoc(card: Card): Y.Doc {
-    const yDoc = new Y.Doc()
-    const yMeta = yDoc.getMap('meta')
+export function createEmptyDocSnapshot(card: Card): DocSnapshot {
+    const pageId = `page:${card.id}`
+    const surfaceId = Utils.createGuid(IDType.None)
+    const noteId = Utils.createGuid(IDType.None)
+    const paragraphId = Utils.createGuid(IDType.None)
 
-    yMeta.set('blockOrder', [])
-    yMeta.set('cardId', card.id)
-    yMeta.set('cardTitle', card.title || '')
+    const emptyParagraph: BlockSnapshot = {
+        type: 'block',
+        id: paragraphId,
+        flavour: 'affine:paragraph',
+        props: {
+            type: 'text',
+            text: {
+                '$blocksuite:internal:text$': true,
+                delta: [],
+            },
+        },
+        children: [],
+    }
 
-    return yDoc
+    const noteBlock: BlockSnapshot = {
+        type: 'block',
+        id: noteId,
+        flavour: 'affine:note',
+        props: {
+            xywh: '[0,0,800,600]',
+            background: '--affine-background-secondary-color',
+            index: 'a0',
+            hidden: false,
+            displayMode: 'both',
+        },
+        children: [emptyParagraph],
+    }
+
+    const surfaceBlock: BlockSnapshot = {
+        type: 'block',
+        id: surfaceId,
+        flavour: 'affine:surface',
+        props: {
+            elements: {},
+        },
+        children: [],
+    }
+
+    const pageBlock: BlockSnapshot = {
+        type: 'block',
+        id: pageId,
+        flavour: 'affine:page',
+        props: {
+            title: {
+                '$blocksuite:internal:text$': true,
+                delta: card.title ? [{insert: card.title}] : [],
+            },
+        },
+        children: [surfaceBlock, noteBlock],
+    }
+
+    return {
+        type: 'page',
+        meta: {
+            id: card.id,
+            title: card.title || '',
+            createDate: card.createAt || Date.now(),
+            tags: [],
+        },
+        blocks: pageBlock,
+    }
 }
 
-export {convertBlockToBlockSuite, sortBlocksByContentOrder}
-export type {ConvertedBlock, BlockSuiteBlockType, BlockSuiteProps}
+export {sortBlocksByContentOrder}
+export type {BlockSuiteFlavour}

--- a/webapp/src/components/blockSuite/markdownToDelta.ts
+++ b/webapp/src/components/blockSuite/markdownToDelta.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+interface DeltaAttributes {
+    bold?: true
+    italic?: true
+    strike?: true
+    code?: true
+    link?: string
+}
+
+interface DeltaOp {
+    insert: string
+    attributes?: DeltaAttributes
+}
+
+type TokenType = 'text' | 'bold' | 'italic' | 'strike' | 'code' | 'link'
+
+interface Token {
+    type: TokenType
+    content: string
+    url?: string
+}
+
+const PATTERNS = {
+    link: /^\[([^\]]+)\]\(([^)]+)\)/,
+    bold: /^\*\*(.+?)\*\*/,
+    boldAlt: /^__(.+?)__/,
+    strike: /^~~(.+?)~~/,
+    code: /^`([^`]+)`/,
+    italic: /^\*([^*]+)\*/,
+    italicAlt: /^_([^_]+)_/,
+}
+
+function tokenize(text: string): Token[] {
+    const tokens: Token[] = []
+    let remaining = text
+    let i = 0
+
+    while (i < remaining.length) {
+        const slice = remaining.slice(i)
+
+        const linkMatch = slice.match(PATTERNS.link)
+        if (linkMatch) {
+            if (i > 0) {
+                tokens.push({type: 'text', content: remaining.slice(0, i)})
+            }
+            tokens.push({type: 'link', content: linkMatch[1], url: linkMatch[2]})
+            remaining = remaining.slice(i + linkMatch[0].length)
+            i = 0
+            continue
+        }
+
+        const boldMatch = slice.match(PATTERNS.bold) || slice.match(PATTERNS.boldAlt)
+        if (boldMatch) {
+            if (i > 0) {
+                tokens.push({type: 'text', content: remaining.slice(0, i)})
+            }
+            tokens.push({type: 'bold', content: boldMatch[1]})
+            remaining = remaining.slice(i + boldMatch[0].length)
+            i = 0
+            continue
+        }
+
+        const strikeMatch = slice.match(PATTERNS.strike)
+        if (strikeMatch) {
+            if (i > 0) {
+                tokens.push({type: 'text', content: remaining.slice(0, i)})
+            }
+            tokens.push({type: 'strike', content: strikeMatch[1]})
+            remaining = remaining.slice(i + strikeMatch[0].length)
+            i = 0
+            continue
+        }
+
+        const codeMatch = slice.match(PATTERNS.code)
+        if (codeMatch) {
+            if (i > 0) {
+                tokens.push({type: 'text', content: remaining.slice(0, i)})
+            }
+            tokens.push({type: 'code', content: codeMatch[1]})
+            remaining = remaining.slice(i + codeMatch[0].length)
+            i = 0
+            continue
+        }
+
+        const italicMatch = slice.match(PATTERNS.italic) || slice.match(PATTERNS.italicAlt)
+        if (italicMatch) {
+            const char = remaining[i]
+            const nextChar = remaining[i + 1]
+            const isNotBoldSyntax = !(char === '*' && nextChar === '*') && !(char === '_' && nextChar === '_')
+            if (isNotBoldSyntax) {
+                if (i > 0) {
+                    tokens.push({type: 'text', content: remaining.slice(0, i)})
+                }
+                tokens.push({type: 'italic', content: italicMatch[1]})
+                remaining = remaining.slice(i + italicMatch[0].length)
+                i = 0
+                continue
+            }
+        }
+
+        i++
+    }
+
+    if (remaining.length > 0) {
+        tokens.push({type: 'text', content: remaining})
+    }
+
+    return tokens
+}
+
+function tokensToDelta(tokens: Token[]): DeltaOp[] {
+    const delta: DeltaOp[] = []
+
+    for (const token of tokens) {
+        if (token.content.length === 0) {
+            continue
+        }
+
+        switch (token.type) {
+        case 'text':
+            delta.push({insert: token.content})
+            break
+        case 'bold':
+            delta.push({insert: token.content, attributes: {bold: true}})
+            break
+        case 'italic':
+            delta.push({insert: token.content, attributes: {italic: true}})
+            break
+        case 'strike':
+            delta.push({insert: token.content, attributes: {strike: true}})
+            break
+        case 'code':
+            delta.push({insert: token.content, attributes: {code: true}})
+            break
+        case 'link':
+            delta.push({insert: token.content, attributes: {link: token.url}})
+            break
+        }
+    }
+
+    return delta
+}
+
+export function parseMarkdownToDelta(text: string): DeltaOp[] {
+    if (!text || text.length === 0) {
+        return []
+    }
+
+    const tokens = tokenize(text)
+    return tokensToDelta(tokens)
+}
+
+export function hasMarkdownSyntax(text: string): boolean {
+    if (!text) {
+        return false
+    }
+
+    return /\*\*.+?\*\*/.test(text) ||
+           /__.+?__/.test(text) ||
+           /\*[^*]+\*/.test(text) ||
+           /_[^_]+_/.test(text) ||
+           /~~.+?~~/.test(text) ||
+           /`.+?`/.test(text) ||
+           /\[.+?\]\(.+?\)/.test(text)
+}
+
+export type {DeltaOp, DeltaAttributes}

--- a/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
+++ b/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useState, useEffect, useRef, useCallback, useMemo} from 'react'
+import * as Y from 'yjs'
+
+import {Block} from '../../blocks/block'
+import {Card} from '../../blocks/card'
+import {Utils} from '../../utils'
+
+import blockSuiteApi from './blockSuiteApi'
+import {convertLegacyBlocksToYjsDoc, createEmptyYjsDoc} from './legacyConverter'
+
+const AUTO_SAVE_DELAY_MS = 2000
+const ENABLE_API_SYNC = false
+
+interface UseBlockSuiteEditorProps {
+    card: Card
+    contents: Block[]
+    readonly: boolean
+}
+
+interface UseBlockSuiteEditorReturn {
+    doc: Y.Doc | null
+    loading: boolean
+    error: Error | null
+    saving: boolean
+    save: () => Promise<void>
+}
+
+function debounce<T extends (...args: Parameters<T>) => void>(
+    func: T,
+    wait: number,
+): (...args: Parameters<T>) => void {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+    return (...args: Parameters<T>) => {
+        if (timeoutId) {
+            clearTimeout(timeoutId)
+        }
+        timeoutId = setTimeout(() => {
+            func(...args)
+            timeoutId = null
+        }, wait)
+    }
+}
+
+export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSuiteEditorReturn {
+    const {card, contents, readonly} = props
+    const cardId = card.id
+
+    const [doc, setDoc] = useState<Y.Doc | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<Error | null>(null)
+    const [saving, setSaving] = useState(false)
+
+    const docRef = useRef<Y.Doc | null>(null)
+    const initializedRef = useRef(false)
+
+    const saveToServer = useCallback(async () => {
+        if (!docRef.current || readonly || !ENABLE_API_SYNC) {
+            return
+        }
+
+        setSaving(true)
+        try {
+            const snapshot = Y.encodeStateAsUpdate(docRef.current)
+            await blockSuiteApi.saveDocContent(cardId, snapshot)
+            Utils.log(`BlockSuite doc saved: ${snapshot.byteLength} bytes`)
+        } catch (err) {
+            Utils.logError(`BlockSuite save error: ${err}`)
+        } finally {
+            setSaving(false)
+        }
+    }, [cardId, readonly])
+
+    const debouncedSave = useMemo(
+        () => debounce(saveToServer, AUTO_SAVE_DELAY_MS),
+        [saveToServer],
+    )
+
+    useEffect(() => {
+        if (initializedRef.current) {
+            return
+        }
+        initializedRef.current = true
+
+        async function initializeDoc() {
+            setLoading(true)
+            setError(null)
+
+            try {
+                let yDoc: Y.Doc
+
+                if (ENABLE_API_SYNC) {
+                    const docInfo = await blockSuiteApi.getDocInfo(cardId)
+
+                    if (docInfo) {
+                        const snapshot = await blockSuiteApi.getDocContent(cardId)
+                        yDoc = new Y.Doc()
+
+                        if (snapshot && snapshot.byteLength > 0) {
+                            Y.applyUpdate(yDoc, snapshot)
+                        }
+
+                        Utils.log(`BlockSuite doc loaded: ${snapshot?.byteLength || 0} bytes`)
+                    } else if (contents.length > 0) {
+                        yDoc = convertLegacyBlocksToYjsDoc(contents, card)
+                        Utils.log(`Converted ${contents.length} legacy blocks to Yjs`)
+
+                        if (!readonly) {
+                            const snapshot = Y.encodeStateAsUpdate(yDoc)
+                            await blockSuiteApi.saveDocContent(cardId, snapshot)
+                            Utils.log(`Initial migration saved: ${snapshot.byteLength} bytes`)
+                        }
+                    } else {
+                        yDoc = createEmptyYjsDoc(card)
+                        Utils.log('Created empty Yjs doc')
+                    }
+                } else {
+                    if (contents.length > 0) {
+                        yDoc = convertLegacyBlocksToYjsDoc(contents, card)
+                        Utils.log(`Converted ${contents.length} legacy blocks to Yjs`)
+                    } else {
+                        yDoc = createEmptyYjsDoc(card)
+                        Utils.log('Created empty Yjs doc')
+                    }
+                }
+
+                docRef.current = yDoc
+                setDoc(yDoc)
+
+                if (!readonly && ENABLE_API_SYNC) {
+                    yDoc.on('update', () => {
+                        debouncedSave()
+                    })
+                }
+            } catch (err) {
+                Utils.logError(`BlockSuite init error: ${err}`)
+                setError(err instanceof Error ? err : new Error(String(err)))
+            } finally {
+                setLoading(false)
+            }
+        }
+
+        initializeDoc()
+
+        return () => {
+            if (docRef.current) {
+                docRef.current.destroy()
+                docRef.current = null
+            }
+        }
+    }, [cardId, card, contents, readonly, debouncedSave])
+
+    return {
+        doc,
+        loading,
+        error,
+        saving,
+        save: saveToServer,
+    }
+}
+
+export default useBlockSuiteEditor

--- a/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
+++ b/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
@@ -10,6 +10,7 @@ import {Utils} from '../../utils'
 
 import blockSuiteApi from './blockSuiteApi'
 import {convertLegacyBlocksToDocSnapshot, createEmptyDocSnapshot} from './legacyConverter'
+import {prepareSnapshotForSave, restoreSnapshotBlobMappings} from './focalboardBlobSource'
 
 const AUTO_SAVE_DELAY_MS = 2000
 const ENABLE_API_SYNC = true
@@ -59,7 +60,8 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
         setSaveStatus('saving')
 
         try {
-            await blockSuiteApi.saveDocContent(cardId, snapshotToSave)
+            const preparedSnapshot = prepareSnapshotForSave(snapshotToSave, card.boardId)
+            await blockSuiteApi.saveDocContent(cardId, preparedSnapshot)
             Utils.log(`BlockSuite snapshot saved for card: ${cardId}`)
             setSaveStatus('saved')
 
@@ -78,7 +80,7 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
         } finally {
             savingRef.current = false
         }
-    }, [cardId, readonly])
+    }, [cardId, card.boardId, readonly])
 
     const scheduleSave = useCallback((snapshotToSave: DocSnapshot) => {
         if (readonly || !ENABLE_API_SYNC) {
@@ -120,6 +122,10 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
                         loadedSnapshot = await blockSuiteApi.getDocContent(cardId)
                         Utils.log(`BlockSuite snapshot loaded for card: ${cardId}`)
                         Utils.log(`useBlockSuiteEditor: Loaded snapshot type=${loadedSnapshot?.type}`)
+
+                        if (loadedSnapshot) {
+                            restoreSnapshotBlobMappings(loadedSnapshot, card.boardId)
+                        }
                     }
                 }
 

--- a/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
+++ b/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
@@ -61,6 +61,8 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
 
         try {
             const preparedSnapshot = prepareSnapshotForSave(snapshotToSave, card.boardId)
+            const blobMapSize = (preparedSnapshot as {meta?: {blobMap?: Record<string, string>}}).meta?.blobMap
+            Utils.log(`BlockSuite saving snapshot, blobMap entries: ${blobMapSize ? Object.keys(blobMapSize).length : 0}`)
             await blockSuiteApi.saveDocContent(cardId, preparedSnapshot)
             Utils.log(`BlockSuite snapshot saved for card: ${cardId}`)
             setSaveStatus('saved')

--- a/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
+++ b/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
@@ -1,18 +1,20 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useState, useEffect, useRef, useCallback, useMemo} from 'react'
-import * as Y from 'yjs'
+import {useState, useEffect, useRef, useCallback} from 'react'
+import type {DocSnapshot} from '@blocksuite/store'
 
 import {Block} from '../../blocks/block'
 import {Card} from '../../blocks/card'
 import {Utils} from '../../utils'
 
 import blockSuiteApi from './blockSuiteApi'
-import {convertLegacyBlocksToYjsDoc, createEmptyYjsDoc} from './legacyConverter'
+import {convertLegacyBlocksToDocSnapshot, createEmptyDocSnapshot} from './legacyConverter'
 
 const AUTO_SAVE_DELAY_MS = 2000
-const ENABLE_API_SYNC = false
+const ENABLE_API_SYNC = true
+
+type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error'
 
 interface UseBlockSuiteEditorProps {
     card: Card
@@ -21,63 +23,78 @@ interface UseBlockSuiteEditorProps {
 }
 
 interface UseBlockSuiteEditorReturn {
-    doc: Y.Doc | null
+    snapshot: DocSnapshot | null
     loading: boolean
     error: Error | null
-    saving: boolean
-    save: () => Promise<void>
-}
-
-function debounce<T extends (...args: Parameters<T>) => void>(
-    func: T,
-    wait: number,
-): (...args: Parameters<T>) => void {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null
-
-    return (...args: Parameters<T>) => {
-        if (timeoutId) {
-            clearTimeout(timeoutId)
-        }
-        timeoutId = setTimeout(() => {
-            func(...args)
-            timeoutId = null
-        }, wait)
-    }
+    saveStatus: SaveStatus
+    saveSnapshot: (snapshot: DocSnapshot) => Promise<void>
+    scheduleSave: (snapshot: DocSnapshot) => void
 }
 
 export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSuiteEditorReturn {
     const {card, contents, readonly} = props
     const cardId = card.id
 
-    const [doc, setDoc] = useState<Y.Doc | null>(null)
+    const [snapshot, setSnapshot] = useState<DocSnapshot | null>(null)
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<Error | null>(null)
-    const [saving, setSaving] = useState(false)
+    const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
 
-    const docRef = useRef<Y.Doc | null>(null)
     const initializedRef = useRef(false)
+    const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const pendingSnapshotRef = useRef<DocSnapshot | null>(null)
+    const savingRef = useRef(false)
 
-    const saveToServer = useCallback(async () => {
-        if (!docRef.current || readonly || !ENABLE_API_SYNC) {
+    const saveSnapshot = useCallback(async (snapshotToSave: DocSnapshot) => {
+        if (readonly || !ENABLE_API_SYNC) {
             return
         }
 
-        setSaving(true)
+        if (savingRef.current) {
+            pendingSnapshotRef.current = snapshotToSave
+            return
+        }
+
+        savingRef.current = true
+        setSaveStatus('saving')
+
         try {
-            const snapshot = Y.encodeStateAsUpdate(docRef.current)
-            await blockSuiteApi.saveDocContent(cardId, snapshot)
-            Utils.log(`BlockSuite doc saved: ${snapshot.byteLength} bytes`)
+            await blockSuiteApi.saveDocContent(cardId, snapshotToSave)
+            Utils.log(`BlockSuite snapshot saved for card: ${cardId}`)
+            setSaveStatus('saved')
+
+            setTimeout(() => {
+                setSaveStatus((current) => (current === 'saved' ? 'idle' : current))
+            }, 3000)
+
+            if (pendingSnapshotRef.current) {
+                const pending = pendingSnapshotRef.current
+                pendingSnapshotRef.current = null
+                setTimeout(() => saveSnapshot(pending), 100)
+            }
         } catch (err) {
             Utils.logError(`BlockSuite save error: ${err}`)
+            setSaveStatus('error')
         } finally {
-            setSaving(false)
+            savingRef.current = false
         }
     }, [cardId, readonly])
 
-    const debouncedSave = useMemo(
-        () => debounce(saveToServer, AUTO_SAVE_DELAY_MS),
-        [saveToServer],
-    )
+    const scheduleSave = useCallback((snapshotToSave: DocSnapshot) => {
+        if (readonly || !ENABLE_API_SYNC) {
+            return
+        }
+
+        if (saveTimeoutRef.current) {
+            clearTimeout(saveTimeoutRef.current)
+        }
+
+        setSaveStatus('pending')
+        saveTimeoutRef.current = setTimeout(() => {
+            saveSnapshot(snapshotToSave)
+            saveTimeoutRef.current = null
+        }, AUTO_SAVE_DELAY_MS)
+    }, [readonly, saveSnapshot])
 
     useEffect(() => {
         if (initializedRef.current) {
@@ -85,80 +102,70 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
         }
         initializedRef.current = true
 
-        async function initializeDoc() {
+        async function initializeSnapshot() {
             setLoading(true)
             setError(null)
 
+            Utils.log(`useBlockSuiteEditor: Initializing for card ${cardId}, contents=${contents.length}`)
+
             try {
-                let yDoc: Y.Doc
+                let loadedSnapshot: DocSnapshot | null = null
 
                 if (ENABLE_API_SYNC) {
+                    Utils.log('useBlockSuiteEditor: Checking for existing doc...')
                     const docInfo = await blockSuiteApi.getDocInfo(cardId)
+                    Utils.log(`useBlockSuiteEditor: docInfo=${docInfo ? 'found' : 'not found'}`)
 
                     if (docInfo) {
-                        const snapshot = await blockSuiteApi.getDocContent(cardId)
-                        yDoc = new Y.Doc()
-
-                        if (snapshot && snapshot.byteLength > 0) {
-                            Y.applyUpdate(yDoc, snapshot)
-                        }
-
-                        Utils.log(`BlockSuite doc loaded: ${snapshot?.byteLength || 0} bytes`)
-                    } else if (contents.length > 0) {
-                        yDoc = convertLegacyBlocksToYjsDoc(contents, card)
-                        Utils.log(`Converted ${contents.length} legacy blocks to Yjs`)
-
-                        if (!readonly) {
-                            const snapshot = Y.encodeStateAsUpdate(yDoc)
-                            await blockSuiteApi.saveDocContent(cardId, snapshot)
-                            Utils.log(`Initial migration saved: ${snapshot.byteLength} bytes`)
-                        }
-                    } else {
-                        yDoc = createEmptyYjsDoc(card)
-                        Utils.log('Created empty Yjs doc')
+                        loadedSnapshot = await blockSuiteApi.getDocContent(cardId)
+                        Utils.log(`BlockSuite snapshot loaded for card: ${cardId}`)
+                        Utils.log(`useBlockSuiteEditor: Loaded snapshot type=${loadedSnapshot?.type}`)
                     }
-                } else {
+                }
+
+                if (!loadedSnapshot) {
                     if (contents.length > 0) {
-                        yDoc = convertLegacyBlocksToYjsDoc(contents, card)
-                        Utils.log(`Converted ${contents.length} legacy blocks to Yjs`)
+                        loadedSnapshot = convertLegacyBlocksToDocSnapshot(contents, card)
+                        Utils.log(`Converted ${contents.length} legacy blocks to DocSnapshot`)
+
+                        if (!readonly && ENABLE_API_SYNC) {
+                            await blockSuiteApi.saveDocContent(cardId, loadedSnapshot)
+                            Utils.log('Initial migration snapshot saved')
+                        }
                     } else {
-                        yDoc = createEmptyYjsDoc(card)
-                        Utils.log('Created empty Yjs doc')
+                        loadedSnapshot = createEmptyDocSnapshot(card)
+                        Utils.log('Created empty DocSnapshot')
                     }
                 }
 
-                docRef.current = yDoc
-                setDoc(yDoc)
-
-                if (!readonly && ENABLE_API_SYNC) {
-                    yDoc.on('update', () => {
-                        debouncedSave()
-                    })
-                }
+                Utils.log(`useBlockSuiteEditor: Setting snapshot, type=${loadedSnapshot?.type}`)
+                setSnapshot(loadedSnapshot)
             } catch (err) {
                 Utils.logError(`BlockSuite init error: ${err}`)
+                console.error('useBlockSuiteEditor error details:', err)
                 setError(err instanceof Error ? err : new Error(String(err)))
             } finally {
                 setLoading(false)
+                Utils.log('useBlockSuiteEditor: Loading complete')
             }
         }
 
-        initializeDoc()
+        initializeSnapshot()
 
         return () => {
-            if (docRef.current) {
-                docRef.current.destroy()
-                docRef.current = null
+            if (saveTimeoutRef.current) {
+                clearTimeout(saveTimeoutRef.current)
             }
         }
-    }, [cardId, card, contents, readonly, debouncedSave])
+    }, [cardId, card, contents, readonly])
 
     return {
-        doc,
+        snapshot,
         loading,
         error,
-        saving,
-        save: saveToServer,
+        saveStatus,
+        saveSnapshot,
+        scheduleSave,
     }
 }
 

--- a/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
+++ b/webapp/src/components/blockSuite/useBlockSuiteEditor.ts
@@ -3,17 +3,39 @@
 
 import {useState, useEffect, useRef, useCallback} from 'react'
 import type {DocSnapshot} from '@blocksuite/store'
+import {Schema, DocCollection, Job} from '@blocksuite/store'
+import {AffineSchemas} from '@blocksuite/blocks'
+import {MarkdownAdapter} from '@blocksuite/blocks'
 
 import {Block} from '../../blocks/block'
 import {Card} from '../../blocks/card'
 import {Utils} from '../../utils'
 
 import blockSuiteApi from './blockSuiteApi'
-import {convertLegacyBlocksToDocSnapshot, createEmptyDocSnapshot} from './legacyConverter'
+import {convertLegacyBlocksToDocSnapshot, convertLegacyBlocksToMarkdown, hasComplexMarkdown, createEmptyDocSnapshot} from './legacyConverter'
 import {prepareSnapshotForSave, restoreSnapshotBlobMappings} from './focalboardBlobSource'
 
 const AUTO_SAVE_DELAY_MS = 2000
 const ENABLE_API_SYNC = true
+
+async function convertMarkdownToDocSnapshot(markdownText: string, card: Card): Promise<DocSnapshot> {
+    const schema = new Schema().register(AffineSchemas)
+    const collection = new DocCollection({schema})
+    collection.meta.initialize()
+
+    const job = new Job({collection})
+    const adapter = new MarkdownAdapter(job)
+
+    const docSnapshot = await adapter.toDocSnapshot({
+        file: markdownText,
+    })
+
+    docSnapshot.meta.id = card.id
+    docSnapshot.meta.title = card.title || ''
+    docSnapshot.meta.createDate = card.createAt || Date.now()
+
+    return docSnapshot
+}
 
 type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error'
 
@@ -133,7 +155,13 @@ export function useBlockSuiteEditor(props: UseBlockSuiteEditorProps): UseBlockSu
 
                 if (!loadedSnapshot) {
                     if (contents.length > 0) {
-                        loadedSnapshot = convertLegacyBlocksToDocSnapshot(contents, card)
+                        if (hasComplexMarkdown(contents)) {
+                            Utils.log('useBlockSuiteEditor: Using MarkdownAdapter for complex markdown')
+                            const markdownText = convertLegacyBlocksToMarkdown(contents, card)
+                            loadedSnapshot = await convertMarkdownToDocSnapshot(markdownText, card)
+                        } else {
+                            loadedSnapshot = convertLegacyBlocksToDocSnapshot(contents, card)
+                        }
                         Utils.log(`Converted ${contents.length} legacy blocks to DocSnapshot`)
 
                         if (!readonly && ENABLE_API_SYNC) {

--- a/webapp/src/components/cardDetail/cardDetail.tsx
+++ b/webapp/src/components/cardDetail/cardDetail.tsx
@@ -82,7 +82,8 @@ const CardDetail = (props: Props): JSX.Element|null => {
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
     const newBoardsEditor = clientConfig?.featureFlags?.newBoardsEditor ?? true
 
-    useImagePaste(props.board.id, card.id, card.fields.contentOrder)
+    // Disable legacy image paste when using BlockSuite editor (it handles its own paste)
+    useImagePaste(props.board.id, card.id, card.fields.contentOrder, !newBoardsEditor)
 
     useEffect(() => {
         if (!title) {
@@ -245,6 +246,7 @@ const CardDetail = (props: Props): JSX.Element|null => {
                         card={card}
                         contents={props.contents.flatMap((b) => b)}
                         readonly={props.readonly || !canEditBoardCards}
+                        teamId={props.board.teamId}
                     />
                 )}
                

--- a/webapp/src/components/cardDetail/cardDetail.tsx
+++ b/webapp/src/components/cardDetail/cardDetail.tsx
@@ -8,12 +8,11 @@ import {BlockIcons} from '../../blockIcons'
 import {Card} from '../../blocks/card'
 import {BoardView} from '../../blocks/boardView'
 import {Board} from '../../blocks/board'
-import {CommentBlock} from '../../blocks/commentBlock' 
+import {CommentBlock} from '../../blocks/commentBlock'
 import {AttachmentBlock} from '../../blocks/attachmentBlock'
 import {ContentBlock} from '../../blocks/contentBlock'
 import {Block} from '../../blocks/block'
 import mutator from '../../mutator'
-// import octoClient from '../../octoClient' // 미사용
 import Button from '../../widgets/buttons/button'
 import {Focusable} from '../../widgets/editable'
 import EditableArea from '../../widgets/editableArea'
@@ -22,16 +21,20 @@ import TelemetryClient, {TelemetryActions, TelemetryCategory} from '../../teleme
 
 import BlockIconSelector from '../blockIconSelector'
 
-import ErrorBoundary from '../../error_boundary'
-import {useAppDispatch} from '../../store/hooks'
+import {useAppDispatch, useAppSelector} from '../../store/hooks'
 import {setCurrent as setCurrentCard} from '../../store/cards'
 import {Permission} from '../../constants'
 import {useHasCurrentBoardPermissions} from '../../hooks/permissions'
-import {BlockSuiteEditor} from '../blockSuite/BlockSuiteEditor'
+import BlockSuiteEditor from '../blockSuite/BlockSuiteEditor'
+import {ClientConfig} from '../../config/clientConfig'
+import {getClientConfig} from '../../store/clientConfig'
 
 import CardSkeleton from '../../svg/card-skeleton'
 
 import CommentsList from './commentsList'
+import {CardDetailProvider} from './cardDetailContext'
+import CardDetailContents from './cardDetailContents'
+import CardDetailContentsMenu from './cardDetailContentsMenu'
 import CardDetailProperties from './cardDetailProperties'
 import useImagePaste from './imagePaste'
 import AttachmentList from './attachment'
@@ -58,11 +61,6 @@ type Props = {
     addAttachment: () => void
 }
 
-// addBlockNewEditor 함수는 현재 사용되지 않음 (BlockSuite 에디터로 대체됨)
-// async function addBlockNewEditor(card: Card, intl: IntlShape, title: string, fields: any, contentType: ContentBlockTypes, afterBlockId: string, dispatch: any): Promise<Block> {
-//     ...
-// }
-
 const CardDetail = (props: Props): JSX.Element|null => {
     const {card, comments, attachments, onDelete, addAttachment} = props
     const {limited} = card
@@ -80,6 +78,9 @@ const CardDetail = (props: Props): JSX.Element|null => {
     const saveTitleRef = useRef<() => void>(saveTitle)
     saveTitleRef.current = saveTitle
     const intl = useIntl()
+
+    const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
+    const newBoardsEditor = clientConfig?.featureFlags?.newBoardsEditor ?? true
 
     useImagePaste(props.board.id, card.id, card.fields.contentOrder)
 
@@ -116,11 +117,6 @@ const CardDetail = (props: Props): JSX.Element|null => {
     if (!card) {
         return null
     }
-
-    // blocks 변수는 현재 사용되지 않음 (BlockSuite 에디터로 대체됨)
-    // const blocks = useMemo(() => props.contents.flatMap((value: Block | Block[]): BlockData<any> => {
-    //     ...
-    // }), [props.contents])
 
     return (
         <>
@@ -243,14 +239,15 @@ const CardDetail = (props: Props): JSX.Element|null => {
 
             {/* Content blocks */}
 
-            {!limited && <div className='CardDetail content-blocks'>
-                <ErrorBoundary>
+            {!limited && <div className='CardDetail CardDetail--fullwidth content-blocks'>
+                {newBoardsEditor && (
                     <BlockSuiteEditor
                         card={card}
-                        boardId={card.boardId}
-                        readOnly={props.readonly || !canEditBoardCards}
+                        contents={props.contents.flatMap((b) => b)}
+                        readonly={props.readonly || !canEditBoardCards}
                     />
-                </ErrorBoundary>
+                )}
+               
             </div>}
         </>
     )

--- a/webapp/src/components/cardDetail/imagePaste.tsx
+++ b/webapp/src/components/cardDetail/imagePaste.tsx
@@ -11,7 +11,7 @@ import {Block} from '../../blocks/block'
 import octoClient from '../../octoClient'
 import mutator from '../../mutator'
 
-export default function useImagePaste(boardId: string, cardId: string, contentOrder: Array<string | string[]>): void {
+export default function useImagePaste(boardId: string, cardId: string, contentOrder: Array<string | string[]>, enabled: boolean = true): void {
     const intl = useIntl()
     const uploadItems = useCallback(async (items: FileList) => {
         let newImage: File|null = null
@@ -76,11 +76,14 @@ export default function useImagePaste(boardId: string, cardId: string, contentOr
     }, [uploadItems])
 
     useEffect(() => {
+        if (!enabled) {
+            return
+        }
         document.addEventListener('paste', onPaste)
         document.addEventListener('drop', onDrop)
         return () => {
             document.removeEventListener('paste', onPaste)
             document.removeEventListener('drop', onDrop)
         }
-    }, [uploadItems, onPaste, onDrop])
+    }, [uploadItems, onPaste, onDrop, enabled])
 }

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -653,7 +653,10 @@ class OctoClient {
         if (readToken) {
             path += `?read_token=${readToken}`
         }
-        const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'GET',
+            headers: this.headers(),
+        }))
         let fileInfo: FileInfo = {}
 
         if (response.status === 200) {
@@ -665,13 +668,21 @@ class OctoClient {
         return fileInfo
     }
 
-    async getFileAsDataUrl(boardId: string, fileId: string): Promise<FileInfo> {
-        let path = '/api/v2/files/teams/' + this.teamId + '/' + boardId + '/' + fileId
+    async getFileAsDataUrl(boardId: string, fileId: string, teamId?: string): Promise<FileInfo> {
+        // Use provided teamId, or fall back to teamPath logic (handles globalTeamId -> lastTeamId)
+        let effectiveTeamId = teamId
+        if (!effectiveTeamId) {
+            effectiveTeamId = this.teamId === Constants.globalTeamId ? UserSettings.lastTeamId || this.teamId : this.teamId
+        }
+        let path = '/api/v2/files/teams/' + effectiveTeamId + '/' + boardId + '/' + fileId
         const readToken = Utils.getReadToken()
         if (readToken) {
             path += `?read_token=${readToken}`
         }
-        const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'GET',
+            headers: this.headers(),
+        }))
         let fileInfo: FileInfo = {}
 
         if (response.status === 200) {

--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -26,10 +26,25 @@ function makeCommonConfig() {
                     },
                 },
                 {
+                    test: /\.m?js$/,
+                    include: /node_modules\/@blocksuite/,
+                    resolve: {
+                        fullySpecified: false,
+                    },
+                },
+                {
+                    test: /\.m?js$/,
+                    include: /node_modules\/yjs/,
+                    resolve: {
+                        fullySpecified: false,
+                    },
+                },
+                {
                     test: /\.tsx?$/,
                     use: {
                         loader: 'ts-loader',
                         options: {
+                            transpileOnly: true,
                             getCustomTransformers: {
                                 before: [
                                     tsTransformer.transform({
@@ -82,10 +97,12 @@ function makeCommonConfig() {
                 'node_modules',
                 path.resolve(__dirname),
             ],
+            alias: {
+                '@blocksuite/store/src': path.resolve(__dirname, './node_modules/@blocksuite/store/dist'),
+            },
             fullySpecified: false,
             extensions: ['.js', '.jsx', '.ts', '.tsx'],
-            // BlockSuite ESM 패키지 지원을 위한 conditionNames 설정
-            conditionNames: ['import', 'require', 'module', 'browser', 'default'],
+            conditionNames: ['import', 'module', 'browser', 'default'],
         },
         plugins: [
             new CopyPlugin({

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -63,28 +63,35 @@ const config = {
         ],
         alias: {
             moment: path.resolve(__dirname, './node_modules/moment/'),
-            // yjs ESM 모듈 명시적 지정
-            yjs: path.resolve(__dirname, './node_modules/yjs/dist/yjs.mjs'),
+            '@blocksuite/store/src': path.resolve(__dirname, './node_modules/@blocksuite/store/dist'),
         },
-        extensions: ['*', '.js', '.jsx', '.ts', '.tsx', '.mjs'],
-        // ESM 모듈 지원을 위한 설정
-        mainFields: ['module', 'browser', 'main'],
+        extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
         fullySpecified: false,
+        conditionNames: ['import', 'module', 'browser', 'default'],
     },
     module: {
         rules: [
-            // ESM 모듈 처리 (BlockSuite, yjs, lib0 등)
             {
                 test: /\.m?js$/,
+                include: /node_modules\/@blocksuite/,
                 resolve: {
                     fullySpecified: false,
                 },
             },
             {
+                test: /\.m?js$/,
+                include: /node_modules\/yjs/,
+                resolve: {
+                    fullySpecified: false,
+                },
+            },
+            
+            {
                 test: /\.tsx?$/,
                 use: {
                     loader: 'ts-loader',
                     options: {
+                        transpileOnly: true,
                         getCustomTransformers: {
                             before: [
                                 tsTransformer.transform({
@@ -129,7 +136,7 @@ const config = {
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
-                    publicPath: TARGET_IS_PRODUCT ? undefined : 'static/',
+                    publicPath: TARGET_IS_PRODUCT ? undefined : '/static/',
                 }
             },
             {
@@ -137,7 +144,7 @@ const config = {
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
-                    publicPath: TARGET_IS_PRODUCT ? undefined : 'static/',
+                    publicPath: TARGET_IS_PRODUCT ? undefined : '/plugins/focalboard/static/',
                 }
             },
         ],
@@ -218,9 +225,17 @@ if (TARGET_IS_PRODUCT) {
     config.output = {
         devtoolNamespace: PLUGIN_ID,
         path: path.join(__dirname, '/dist'),
-        publicPath: '/',
+        publicPath: '/static/plugins/focalboard/',
         filename: 'main.js',
     };
+
+    // Disable code splitting for plugin environment
+    // BlockSuite uses dynamic imports which cause chunk loading issues in Mattermost plugin context
+    config.plugins.push(
+        new webpack.optimize.LimitChunkCountPlugin({
+            maxChunks: 1,
+        }),
+    );
 }
 
 const env = {};


### PR DESCRIPTION
## 요약
BlockSuite의 비교적 최신버전인 19~22를 모두 테스트 해봤지만 웹팩과 호환성이 안좋아서 BlockSuite 마운트가 안되는 문제가 있었습니다. 그래서 가장 안정적인 17 버전으로 다운그레이드했습니다.

BlockSuite 에디터를 카드 상세 화면에 통합하고, 기존 콘텐츠를 새로운 에디터 형식으로 변환하는 레거시 변환기를 구현했습니다.

## 주요 변경사항
- Content & Media에 속한 부분 기능들 동작 되도록 변경
- 이미지가 간헐적으로 저장이 안되거나 무한 로딩 보이는 현상 수정
<img width="663" height="697" alt="스크린샷 2026-01-24 오전 12 57 13" src="https://github.com/user-attachments/assets/00667d65-eb2c-4a5c-a7c6-beeda8c0294a" />
<img width="713" height="664" alt="스크린샷 2026-01-24 오전 12 57 18" src="https://github.com/user-attachments/assets/7d901ddb-edf9-424f-b1d7-8dc42a62d162" />
<img width="828" height="733" alt="스크린샷 2026-01-24 오전 12 57 35" src="https://github.com/user-attachments/assets/788f4b87-a563-44a9-8f78-336a7fd94420" />


### 서버
- **파일 참조 검증**: 보드 내 BlockSuite 문서에서 파일이 참조되는지 확인하는 메서드 추가
- **문서 조회 개선**: BlockSuite 문서 조회 메서드의 캡슐화 및 일관성 향상
- **로깅 개선**: 디버깅을 위한 로깅 메시지 개선

### 의존성
- @blocksuite 패키지들 버전 0.17.33으로 다운그레이드
- 패키지 설치 후 BlockSuite 패치 스크립트 추가

## 변경된 파일

| 영역 | 파일 수 | 주요 파일 |
|------|---------|----------|
| 서버 | 4개 | `files.go`, `blocksuite.go`, `store.go` |
| 웹앱 | 17개 | `BlockSuiteEditor.tsx`, `legacyConverter.ts`, `useBlockSuiteEditor.ts` |
| 설정/문서 | 6개 | `AGENTS.md`, `package.json`, `webpack.config.js` |

## 테스트
- [x] 기존 카드 콘텐츠가 새 에디터에서 올바르게 표시되는지 확인
- [x] 에디터에서 콘텐츠 편집 및 저장 동작 확인
- [x] 이미지 첨부 및 blob 매핑 동작 확인
- [x] 저장 상태 표시가 정상적으로 동작하는지 확인