### PR TITLE
TypeScript 5.x 업그레이드 및 tsconfig 설정 개선

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -111,7 +111,7 @@
 				"terser-webpack-plugin": "^5.3.1",
 				"ts-jest": "^27.1.4",
 				"ts-loader": "^9.2.8",
-				"typescript": "^4.6.3",
+				"typescript": "^5.7.0",
 				"webpack": "^5.70.0",
 				"webpack-cli": "^4.9.2",
 				"webpack-dev-server": "^4.11.1",
@@ -1593,6 +1593,20 @@
 				}
 			}
 		},
+		"node_modules/@formatjs/cli/node_modules/typescript": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/@formatjs/ecma402-abstract": {
 			"version": "1.11.4",
 			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
@@ -1774,20 +1788,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
-			}
-		},
-		"node_modules/@formatjs/ts-transformer/node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
 			}
 		},
 		"node_modules/@fullcalendar/common": {
@@ -22577,9 +22577,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -22587,7 +22587,7 @@
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/ua-parser-js": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -166,7 +166,7 @@
 		"terser-webpack-plugin": "^5.3.1",
 		"ts-jest": "^27.1.4",
 		"ts-loader": "^9.2.8",
-		"typescript": "^4.6.3",
+		"typescript": "^5.7.0",
 		"webpack": "^5.70.0",
 		"webpack-cli": "^4.9.2",
 		"webpack-dev-server": "^4.11.1",

--- a/webapp/src/tsconfig.json
+++ b/webapp/src/tsconfig.json
@@ -1,13 +1,7 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"*": [
-				"../node_modules/*",
-				"../@custom_types/*"
-			]
-		}
+		"baseUrl": "."
 	},
 	"include": [
 		"./**/*.ts",

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "jsx": "react",
         "target": "es2019",
-        "module": "commonjs",
+        "module": "ESNext",
         "esModuleInterop": true,
         "noImplicitAny": true,
         "strict": true,
@@ -14,9 +14,9 @@
         "incremental": false,
         "baseUrl": "src",
         "outDir": "./dist",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "skipLibCheck": true,
-        "types": ["jest", "node"],
+        "typeRoots": ["./node_modules/@types"]
     },
     "include": [
 		"src/**/*"


### PR DESCRIPTION
## 요약

TypeScript를 5.7.0으로 업그레이드하고 tsconfig 설정을 최신화 하여 타입 에러 문제를 해결합니다.

## 변경 사항

### TypeScript 업그레이드
- `typescript`: 4.6.3 → 5.7.0

### tsconfig.json 설정 변경
- `module`: `commonjs` → `ESNext`
- `moduleResolution`: `node` → `bundler`
- `types` → `typeRoots`: `@types/*` 패키지 자동 탐색 활성화

### src/tsconfig.json 정리
- 레거시 `paths` 설정 제거 (존재하지 않는 `@custom_types` 참조 포함)
- `moduleResolution: bundler`와 충돌하던 와일드카드 패턴 제거

## 해결된 문제

- `react-router-dom` 등 `@types/*` 패키지의 타입 선언 파일을 찾을 수 없는 에러 해결
- TS7016: Could not find a declaration file for module 에러 해결

## 테스트

- [x] `npm run check-types` 통과
- [x] `npx tsc -p src/tsconfig.json --noEmit` 통과