### PR TITLE
BlockSuite 에디터 토글 리스트 추가 및 렌더링 수정

### DIFF
--- a/webapp/src/blockSuitePatch.ts
+++ b/webapp/src/blockSuitePatch.ts
@@ -1,0 +1,51 @@
+
+// Use dynamic imports to prevent hoisting issues
+// This ensures that @blocksuite/blocks and @blocksuite/affine-components/icons
+// are ONLY loaded when this function is called, not when the module is imported.
+
+export async function patchSlashMenu() {
+    try {
+        console.log('[BlockSuitePatch] Starting dynamic patch...');
+        
+        // Dynamic imports
+        const { AffineSlashMenuWidget } = await import('@blocksuite/blocks');
+        const { toggleRight } = await import('@blocksuite/affine-components/icons');
+
+        const toggleListItem = {
+            name: 'Toggle List',
+            icon: toggleRight,
+            // @ts-ignore
+            action: ({ rootComponent }) => {
+                rootComponent.std.command
+                    .chain()
+                    .updateBlockType({
+                        flavour: 'affine:list',
+                        props: { type: 'toggle' },
+                    })
+                    .run();
+            }
+        };
+
+        // @ts-ignore
+        const items = AffineSlashMenuWidget.DEFAULT_CONFIG.items;
+        
+        // Check if already added to avoid duplicates
+        // @ts-ignore
+        if (items.some((item: any) => item.name === 'Toggle List')) {
+            console.log('[BlockSuitePatch] Toggle List already exists in Slash Menu');
+            return;
+        }
+
+        // @ts-ignore
+        const todoIndex = items.findIndex((item: any) => item.name === 'To-do List');
+        
+        if (todoIndex !== -1) {
+            items.splice(todoIndex + 1, 0, toggleListItem);
+        } else {
+            items.push(toggleListItem);
+        }
+        console.log('[BlockSuitePatch] Toggle List added to Slash Menu successfully');
+    } catch (e) {
+        console.warn('[BlockSuitePatch] Failed to add Toggle List to Slash Menu:', e);
+    }
+}

--- a/webapp/src/components/blockSuite/blockSuite.scss
+++ b/webapp/src/components/blockSuite/blockSuite.scss
@@ -334,3 +334,20 @@ affine-note {
         border-radius: 4px !important;
     }
 }
+
+.affine-list-block-container {
+    .toggle-icon {
+        display: none !important;
+    }
+}
+
+// Ensure the remaining toggle icon behaves correctly
+.affine-list-block__prefix {
+    cursor: pointer;
+    user-select: none;
+
+    // Make sure it aligns correctly
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/webapp/src/components/blockSuite/editor/editor.ts
+++ b/webapp/src/components/blockSuite/editor/editor.ts
@@ -9,6 +9,8 @@ import { effects as presetsEffects } from '@blocksuite/presets/effects'
 blocksEffects()
 presetsEffects()
 
+// Initialize Toggle List in Slash Menu
+
 // Debug: Verify drag handle widget is registered
 if (typeof window !== 'undefined') {
     const isRegistered = customElements.get('affine-drag-handle-widget')

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,10 +1,8 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// Polyfill for global which is expected by some libraries (like Yjs/BlockSuite)
-if (typeof (window as any).global === 'undefined') {
-    (window as any).global = window
-}
+// Ensure global is defined before any other imports
+import './polyfill';
 
 import React, {useEffect} from 'react'
 import {createIntl, createIntlCache} from 'react-intl'
@@ -56,6 +54,7 @@ import {PluginRegistry} from './types/mattermost-webapp'
 import './plugin.scss'
 import CloudUpgradeNudge from "./components/cloudUpgradeNudge/cloudUpgradeNudge"
 import CreateBoardFromTemplate from './components/createBoardFromTemplate'
+import {patchSlashMenu} from 'blockSuitePatch'
 
 const windowAny = (window as SuiteWindow)
 windowAny.baseURL = process.env.TARGET_IS_PRODUCT ? '/plugins/boards' : '/plugins/focalboard'
@@ -173,8 +172,10 @@ export default class Plugin {
     boardSelectorId?: string
     registry?: PluginRegistry
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     async initialize(registry: PluginRegistry, mmStore: Store<GlobalState, Action<Record<string, unknown>>>): Promise<void> {
+        // Patch BlockSuite configurations safely during initialization
+        patchSlashMenu();
+
         const siteURL = mmStore.getState().entities.general.config.SiteURL
         const subpath = siteURL ? getSubpath(siteURL) : ''
         windowAny.frontendBaseURL = subpath + windowAny.frontendBaseURL
@@ -390,8 +391,6 @@ export default class Plugin {
         ))
 
         windowAny.getCurrentTeamId = (): string => {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             return mmStore.getState().entities.teams.currentTeamId
         }
 

--- a/webapp/src/polyfill.ts
+++ b/webapp/src/polyfill.ts
@@ -1,0 +1,8 @@
+// Polyfill for global which is expected by some libraries (like Yjs/BlockSuite)
+// This file must be imported before any other imports in the application entry point.
+
+if (typeof (window as any).global === 'undefined') {
+    (window as any).global = window;
+}
+
+console.log('[Polyfill] globalThis/window.global initialized');


### PR DESCRIPTION
## 개요
BlockSuite 에디터의 슬래시 메뉴(/)에 "Toggle List" 기능을 추가하고, 이와 관련된 초기화 순서 문제 및 UI 버그를 수정했습니다.

## 주요 변경 사항
1. **토글 리스트 기능 추가**:
   - `webapp/src/blockSuitePatch.ts`를 생성하여 런타임에 슬래시 메뉴 구성을 패치합니다.
   - `Dynamic Import`를 사용하여 모듈 의존성 문제를 해결했습니다.

2. **초기화 버그 수정 (Editor Visibility)**:
   - `webapp/src/polyfill.ts`: `window.global` 폴리필을 추가하여 Yjs/BlockSuite 호환성 문제를 해결했습니다.
   - `webapp/src/index.tsx`: 폴리필 우선 로드 및 패치 함수의 비동기 실행을 보장하여 에디터가 보이지 않는 현상을 방지했습니다.

3. **UI 수정**:
   - `webapp/src/components/blockSuite/blockSuite.scss`: 토글 리스트 아이콘이 중복으로 표시되는 문제를 CSS로 해결했습니다.

## 테스트 방법
1. 카드를 열고 에디터에 진입합니다.
2. `/`를 입력하여 슬래시 메뉴를 엽니다.
3. "Toggle List" 항목이 보이고, 아이콘이 하나만 표시되는지 확인합니다.
4. 선택 시 토글 목록이 정상적으로 생성되는지 확인합니다.