### PR TITLE
fix: BlockSuite 에디터 커서 스크롤 동기화

### DIFF
--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -268,6 +268,50 @@ function BlockSuiteEditor(props: Props): JSX.Element {
         }
     }, [containerMounted, snapshot, readonly, card.boardId, teamId, handleDocUpdate])
 
+    useEffect(() => {
+        const handleSelectionChange = () => {
+            requestAnimationFrame(() => {
+                const selection = document.getSelection()
+                if (!selection || selection.rangeCount === 0) {
+                    return
+                }
+
+                if (!containerRef.current || !containerRef.current.contains(selection.anchorNode)) {
+                    return
+                }
+
+                const range = selection.getRangeAt(0)
+                const rect = range.getBoundingClientRect()
+
+                let scrollParent = containerRef.current.parentElement
+                while (scrollParent) {
+                    const style = window.getComputedStyle(scrollParent)
+                    const isScrollable = style.overflowY === 'auto' || style.overflowY === 'scroll' || scrollParent.classList.contains('dialog')
+
+                    if (isScrollable) {
+                        break
+                    }
+                    scrollParent = scrollParent.parentElement
+                }
+
+                if (scrollParent) {
+                    const parentRect = scrollParent.getBoundingClientRect()
+                    const bottomPadding = 40
+
+                    if (rect.bottom > parentRect.bottom - bottomPadding) {
+                        const diff = rect.bottom - (parentRect.bottom - bottomPadding)
+                        scrollParent.scrollTop += diff
+                    }
+                }
+            })
+        }
+
+        document.addEventListener('selectionchange', handleSelectionChange)
+        return () => {
+            document.removeEventListener('selectionchange', handleSelectionChange)
+        }
+    }, [containerMounted])
+
     if (loading) {
         return (
             <div className='BlockSuiteEditor BlockSuiteEditor--loading'>


### PR DESCRIPTION
## 요약
BlockSuite 에디터에서 컨텐츠 입력 중 줄 바꿈 등으로 커서가 화면 아래로 내려갈 때, 스크롤이 자동으로 이동하지 않는 문제를 수정했습니다.

https://github.com/user-attachments/assets/27ff47e1-ce59-459b-b0b5-c12293de0e8c


## 변경 사항
- `BlockSuiteEditor.tsx`에 `selectionchange` 이벤트 리스너 추가
- 커서 위치가 스크롤 가능한 컨테이너(예: 다이얼로그)의 보이는 영역을 벗어날 경우 자동으로 스크롤하도록 로직 구현