### PR TITLE
[Fix] BlockSuite 에디터 오토 포커스 및 타입 오류 수정

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -95,6 +95,7 @@
 				"eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#23abcf9988f7fa00d26929f11841aab7ccb16b2b",
 				"eslint-plugin-no-only-tests": "2.6.0",
 				"eslint-plugin-react": "7.29.4",
+				"eslint-plugin-react-hooks": "^7.0.1",
 				"fetch-mock-jest": "^1.5.1",
 				"file-loader": "^6.2.0",
 				"html-webpack-plugin": "^5.5.0",
@@ -9960,6 +9961,26 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/eslint-plugin-react-hooks": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+			"integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"hermes-parser": "^0.25.1",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-validation-error": "^3.5.0 || ^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+			}
+		},
 		"node_modules/eslint-plugin-react/node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -12178,6 +12199,23 @@
 			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
+			}
+		},
+		"node_modules/hermes-estree": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hermes-parser": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hermes-estree": "0.25.1"
 			}
 		},
 		"node_modules/history": {
@@ -23968,6 +24006,19 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/zwitch": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -150,6 +150,7 @@
 		"eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#23abcf9988f7fa00d26929f11841aab7ccb16b2b",
 		"eslint-plugin-no-only-tests": "2.6.0",
 		"eslint-plugin-react": "7.29.4",
+		"eslint-plugin-react-hooks": "^7.0.1",
 		"fetch-mock-jest": "^1.5.1",
 		"file-loader": "^6.2.0",
 		"html-webpack-plugin": "^5.5.0",

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -17,6 +17,7 @@ import {Block} from '../../blocks/block'
 import {Card} from '../../blocks/card'
 import {Board} from '../../blocks/board'
 import {Utils} from '../../utils'
+import {checkSnapshotHasContent} from '../../utils/blockSuiteUtils'
 import {useAppSelector, useAppDispatch} from '../../store/hooks'
 import {getSortedCards, updateCards} from '../../store/cards'
 import {getBoards, getMySortedBoards} from '../../store/boards'
@@ -236,6 +237,66 @@ function BlockSuiteEditor(props: Props): JSX.Element {
 
                 containerRef.current.innerHTML = ''
                 containerRef.current.appendChild(editor)
+
+                if (!readonly) {
+                    try {
+                        const hasContent = checkSnapshotHasContent(snapshot)
+                        if (!hasContent) {
+                            Utils.log('BlockSuiteEditor: Document is empty, attempting to auto-focus first block')
+                            
+                            const blocks = editorDoc.getBlocks()
+                            let targetBlockId = ''
+
+                            const firstParagraph = blocks.find((b) => b.flavour === 'affine:paragraph')
+                            if (firstParagraph) {
+                                targetBlockId = firstParagraph.id
+                            }
+
+                            if (!targetBlockId && blocks.length > 0) {
+                                const paragraphs = blocks.filter((b) => b.flavour === 'affine:paragraph')
+                                if (paragraphs.length > 0) {
+                                    targetBlockId = paragraphs[0].id
+                                }
+                            }
+
+                            if (targetBlockId && editor.std) {
+                                Utils.log(`BlockSuiteEditor: Focusing block ${targetBlockId}`)
+                                
+                                setTimeout(() => {
+                                    try {
+                                        const selection = editor.std.selection.create('text', {
+                                            from: {
+                                                blockId: targetBlockId,
+                                                index: 0,
+                                                length: 0,
+                                            },
+                                            to: null,
+                                        })
+                                        
+                                        editor.std.selection.set([selection])
+                                        
+                                        if (editor.std.event) {
+                                            editor.std.event.active = true
+                                        }
+                                        
+                                        if (containerRef.current) {
+                                            const editableElement = containerRef.current.querySelector('[contenteditable="true"]') as HTMLElement
+                                            if (editableElement) {
+                                                editableElement.focus()
+                                            }
+                                        }
+                                    } catch (err) {
+                                        Utils.logError(`BlockSuiteEditor: Delayed focus failed: ${err}`)
+                                    }
+                                }, 100)
+                            } else {
+                                Utils.log('BlockSuiteEditor: Could not find suitable block to focus')
+                            }
+                        }
+                    } catch (e) {
+                        Utils.logError(`BlockSuiteEditor: Auto-focus failed: ${e}`)
+                    }
+                }
 
                 editorRef.current = editor
                 collectionRef.current = collection

--- a/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
+++ b/webapp/src/components/blockSuite/BlockSuiteEditor.tsx
@@ -275,8 +275,8 @@ function BlockSuiteEditor(props: Props): JSX.Element {
                                         
                                         editor.std.selection.set([selection])
                                         
-                                        if (editor.std.event) {
-                                            editor.std.event.active = true
+                                        if (editor.std.event && editor.host) {
+                                            editor.host.focus()
                                         }
                                         
                                         if (containerRef.current) {

--- a/webapp/src/utils/blockSuiteUtils.ts
+++ b/webapp/src/utils/blockSuiteUtils.ts
@@ -595,7 +595,7 @@ async function addBlockFromSnapshot(doc: Doc, blockData: any, parentId: string):
  * 스냅샷에 실제 콘텐츠가 있는지 확인
  * 기본 구조(빈 paragraph)만 있으면 false 반환
  */
-function checkSnapshotHasContent(snapshot: any): boolean {
+export function checkSnapshotHasContent(snapshot: any): boolean {
     console.log('[Content Check] Checking snapshot for real content...')
     console.log('[Content Check] Snapshot structure:', snapshot)
     try {


### PR DESCRIPTION
## 개요
BlockSuite 에디터 초기화 시 빈 문서에 대한 오토 포커스 기능을 개선하고, 읽기 전용 속성 관련 타입 오류를 수정했습니다.

## 변경 사항
- **오토 포커스 로직 개선**: 에디터가 마운트된 후 `setTimeout`을 사용하여 확실하게 포커스를 잡도록 변경했습니다.
- **타입 오류 수정**: `editor.std.event.active` 속성이 읽기 전용이므로, 직접 할당하는 대신 `editor.host.focus()`를 호출하여 이벤트를 활성화하도록 수정했습니다.
- **DOM 포커스**: `contenteditable` 요소를 직접 찾아 포커스를 강제하는 로직을 추가하여 포커스 신뢰성을 높였습니다.

## 테스트 방법
1. 빈 페이지/카드를 엽니다.
2. 에디터의 첫 번째 블록에 자동으로 커서가 위치하는지 확인합니다.
3. `npm run check-types`를 실행하여 타입 오류가 없는지 확인합니다.