### PR TITLE
fix: BlockSuite 이미지 다운로드 버튼 동작 수정

### DIFF
--- a/webapp/src/components/blockSuite/focalboardBlobSource.ts
+++ b/webapp/src/components/blockSuite/focalboardBlobSource.ts
@@ -7,6 +7,45 @@ import type {DocSnapshot, BlockSnapshot} from '@blocksuite/store'
 import octoClient from '../../octoClient'
 import {Utils} from '../../utils'
 
+// MIME type mapping for common image extensions
+const extensionToMimeType: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.svg': 'image/svg+xml',
+    '.bmp': 'image/bmp',
+    '.ico': 'image/x-icon',
+    '.tiff': 'image/tiff',
+    '.tif': 'image/tiff',
+    '.avif': 'image/avif',
+}
+
+/**
+ * BlockSuite의 getImageBlob()은 blob.type.startsWith('image/')를 검사합니다.
+ * 서버가 application/octet-stream으로 응답하면 다운로드가 실패하므로,
+ * 파일 확장자에서 올바른 MIME 타입을 추론하여 blob을 재생성합니다.
+ */
+function ensureImageMimeType(blob: Blob, filename: string): Blob {
+    if (blob.type && blob.type.startsWith('image/')) {
+        return blob
+    }
+
+    const lastDotIndex = filename.lastIndexOf('.')
+    if (lastDotIndex !== -1) {
+        const extension = filename.substring(lastDotIndex).toLowerCase()
+        const mimeType = extensionToMimeType[extension]
+        if (mimeType) {
+            Utils.log(`ensureImageMimeType: inferred type ${mimeType} from extension ${extension}`)
+            return new Blob([blob], {type: mimeType})
+        }
+    }
+
+    Utils.log(`ensureImageMimeType: defaulting to image/png for ${filename}`)
+    return new Blob([blob], {type: 'image/png'})
+}
+
 // Module-level maps persist across BlobSource instances
 // Key format: `${boardId}:${blobKey}` -> fileId
 const globalKeyToFileIdMap = new Map<string, string>()
@@ -120,8 +159,10 @@ export function createFocalboardBlobSource(boardId: string, teamId: string): Blo
                     return null
                 }
 
-                const blob = await response.blob()
-                Utils.log(`BlobSource.get: successfully fetched blob, size=${blob.size}`)
+                let blob = await response.blob()
+                Utils.log(`BlobSource.get: successfully fetched blob, size=${blob.size}, type=${blob.type}`)
+
+                blob = ensureImageMimeType(blob, fileId)
 
                 globalBlobCache.set(globalKey, blob)
 


### PR DESCRIPTION
## Summary
- BlockSuite 에디터에서 이미지 호버 시 나타나는 다운로드 버튼 클릭 시 다운로드가 안 되는 버그 수정

## Problem
- BlockSuite의 `getImageBlob()`은 `blob.type.startsWith('image/')`를 검사함
- 서버가 파일 메타데이터 없이 `application/octet-stream`으로 응답하면 검사 실패
- 결과: "Unable to download image!" 토스트 표시 또는 무반응

## Solution
- `focalboardBlobSource.ts`에 `ensureImageMimeType()` 함수 추가
- blob의 MIME 타입이 `image/`로 시작하지 않으면 파일 확장자에서 추론
- 올바른 MIME 타입으로 blob 재생성

## Changes
- `webapp/src/components/blockSuite/focalboardBlobSource.ts`: MIME 타입 추론 로직 추가