### PR TITLE
feat: 댓글 예약 전송 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "okrbest-plugin-boards",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -95,6 +95,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// V3 routes
 	a.registerCardsRoutes(apiv2)
 	a.registerBlockSuiteRoutes(apiv2)
+	a.registerScheduledCommentsRoutes(apiv2)
 
 	// System routes are outside the /api/v2 path
 	a.registerSystemRoutes(r)

--- a/server/api/scheduled_comments.go
+++ b/server/api/scheduled_comments.go
@@ -1,0 +1,434 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
+	"github.com/mattermost/mattermost-plugin-boards/server/services/audit"
+)
+
+// ScheduledCommentRequest represents the request body for creating a scheduled comment.
+type ScheduledCommentRequest struct {
+	CardID      string `json:"cardId"`
+	Title       string `json:"title"`
+	ScheduledAt int64  `json:"scheduledAt"`
+}
+
+// ScheduledCommentUpdateRequest represents the request body for updating a scheduled comment.
+type ScheduledCommentUpdateRequest struct {
+	Title       *string `json:"title,omitempty"`
+	ScheduledAt *int64  `json:"scheduledAt,omitempty"`
+}
+
+func (a *API) registerScheduledCommentsRoutes(r *mux.Router) {
+	// Get my scheduled comments
+	r.HandleFunc("/me/scheduled-comments", a.sessionRequired(a.handleGetMyScheduledComments)).Methods(http.MethodGet)
+
+	// Board-specific scheduled comment routes
+	r.HandleFunc("/boards/{boardID}/scheduled-comments", a.sessionRequired(a.handleCreateScheduledComment)).Methods(http.MethodPost)
+	r.HandleFunc("/boards/{boardID}/cards/{cardID}/scheduled-comments", a.sessionRequired(a.handleGetScheduledCommentsForCard)).Methods(http.MethodGet)
+
+	// Individual scheduled comment operations
+	r.HandleFunc("/boards/{boardID}/scheduled-comments/{blockID}", a.sessionRequired(a.handleUpdateScheduledComment)).Methods(http.MethodPatch)
+	r.HandleFunc("/boards/{boardID}/scheduled-comments/{blockID}/cancel", a.sessionRequired(a.handleCancelScheduledComment)).Methods(http.MethodPost)
+	r.HandleFunc("/boards/{boardID}/scheduled-comments/{blockID}/send-now", a.sessionRequired(a.handleSendScheduledCommentNow)).Methods(http.MethodPost)
+}
+
+func (a *API) handleGetMyScheduledComments(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /me/scheduled-comments getMyScheduledComments
+	//
+	// Returns all pending scheduled comments for the current user
+	//
+	// ---
+	// produces:
+	// - application/json
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       type: array
+	//       items:
+	//         "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	userID := getUserID(r)
+
+	comments, err := a.app.GetMyScheduledComments(userID)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comments)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "getMyScheduledComments", audit.Fail)
+	auditRec.AddMeta("count", len(comments))
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelRead, auditRec)
+}
+
+func (a *API) handleCreateScheduledComment(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /boards/{boardID}/scheduled-comments createScheduledComment
+	//
+	// Creates a new scheduled comment
+	//
+	// ---
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: boardID
+	//   in: path
+	//   description: Board ID
+	//   required: true
+	//   type: string
+	// - name: body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     "$ref": "#/definitions/ScheduledCommentRequest"
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	vars := mux.Vars(r)
+	boardID := vars["boardID"]
+	userID := getUserID(r)
+
+	requestBody := ScheduledCommentRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		a.errorResponse(w, r, model.NewErrBadRequest("invalid request body"))
+		return
+	}
+
+	// Validate required fields
+	if requestBody.CardID == "" {
+		a.errorResponse(w, r, model.NewErrBadRequest("cardId is required"))
+		return
+	}
+	if requestBody.Title == "" {
+		a.errorResponse(w, r, model.NewErrBadRequest("title is required"))
+		return
+	}
+	if requestBody.ScheduledAt == 0 {
+		a.errorResponse(w, r, model.NewErrBadRequest("scheduledAt is required"))
+		return
+	}
+
+	// Check permission to comment on board cards
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionCommentBoardCards) {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to create scheduled comment"))
+		return
+	}
+
+	comment, err := a.app.CreateScheduledComment(boardID, requestBody.CardID, userID, requestBody.Title, requestBody.ScheduledAt)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comment)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "createScheduledComment", audit.Fail)
+	auditRec.AddMeta("boardID", boardID)
+	auditRec.AddMeta("cardID", requestBody.CardID)
+	auditRec.AddMeta("blockID", comment.ID)
+	auditRec.AddMeta("scheduledAt", requestBody.ScheduledAt)
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelModify, auditRec)
+}
+
+func (a *API) handleGetScheduledCommentsForCard(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /boards/{boardID}/cards/{cardID}/scheduled-comments getScheduledCommentsForCard
+	//
+	// Returns scheduled comments for a specific card
+	//
+	// ---
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: boardID
+	//   in: path
+	//   description: Board ID
+	//   required: true
+	//   type: string
+	// - name: cardID
+	//   in: path
+	//   description: Card ID
+	//   required: true
+	//   type: string
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       type: array
+	//       items:
+	//         "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	vars := mux.Vars(r)
+	boardID := vars["boardID"]
+	cardID := vars["cardID"]
+	userID := getUserID(r)
+
+	// Check permission to view board
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionViewBoard) {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to view scheduled comments"))
+		return
+	}
+
+	comments, err := a.app.GetScheduledCommentsForCard(cardID, userID)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comments)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "getScheduledCommentsForCard", audit.Fail)
+	auditRec.AddMeta("boardID", boardID)
+	auditRec.AddMeta("cardID", cardID)
+	auditRec.AddMeta("count", len(comments))
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelRead, auditRec)
+}
+
+func (a *API) handleUpdateScheduledComment(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation PATCH /boards/{boardID}/scheduled-comments/{blockID} updateScheduledComment
+	//
+	// Updates a scheduled comment's content or scheduled time
+	//
+	// ---
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: boardID
+	//   in: path
+	//   description: Board ID
+	//   required: true
+	//   type: string
+	// - name: blockID
+	//   in: path
+	//   description: Block ID
+	//   required: true
+	//   type: string
+	// - name: body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     "$ref": "#/definitions/ScheduledCommentUpdateRequest"
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	vars := mux.Vars(r)
+	boardID := vars["boardID"]
+	blockID := vars["blockID"]
+	userID := getUserID(r)
+
+	// Check permission to comment on board
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionCommentBoardCards) {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to update scheduled comment"))
+		return
+	}
+
+	requestBody := ScheduledCommentUpdateRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		a.errorResponse(w, r, model.NewErrBadRequest("invalid request body"))
+		return
+	}
+
+	comment, err := a.app.UpdateScheduledComment(blockID, userID, requestBody.Title, requestBody.ScheduledAt)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comment)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "updateScheduledComment", audit.Fail)
+	auditRec.AddMeta("boardID", boardID)
+	auditRec.AddMeta("blockID", blockID)
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelModify, auditRec)
+}
+
+func (a *API) handleCancelScheduledComment(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /boards/{boardID}/scheduled-comments/{blockID}/cancel cancelScheduledComment
+	//
+	// Cancels a scheduled comment
+	//
+	// ---
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: boardID
+	//   in: path
+	//   description: Board ID
+	//   required: true
+	//   type: string
+	// - name: blockID
+	//   in: path
+	//   description: Block ID
+	//   required: true
+	//   type: string
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	vars := mux.Vars(r)
+	boardID := vars["boardID"]
+	blockID := vars["blockID"]
+	userID := getUserID(r)
+
+	// Check permission to comment on board
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionCommentBoardCards) {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to cancel scheduled comment"))
+		return
+	}
+
+	comment, err := a.app.CancelScheduledComment(blockID, userID)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comment)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "cancelScheduledComment", audit.Fail)
+	auditRec.AddMeta("boardID", boardID)
+	auditRec.AddMeta("blockID", blockID)
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelModify, auditRec)
+}
+
+func (a *API) handleSendScheduledCommentNow(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /boards/{boardID}/scheduled-comments/{blockID}/send-now sendScheduledCommentNow
+	//
+	// Immediately sends a scheduled comment
+	//
+	// ---
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: boardID
+	//   in: path
+	//   description: Board ID
+	//   required: true
+	//   type: string
+	// - name: blockID
+	//   in: path
+	//   description: Block ID
+	//   required: true
+	//   type: string
+	// security:
+	// - BearerAuth: []
+	// responses:
+	//   '200':
+	//     description: success
+	//     schema:
+	//       "$ref": "#/definitions/Block"
+	//   default:
+	//     description: internal error
+	//     schema:
+	//       "$ref": "#/definitions/ErrorResponse"
+
+	vars := mux.Vars(r)
+	boardID := vars["boardID"]
+	blockID := vars["blockID"]
+	userID := getUserID(r)
+
+	// Check permission to comment on board
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionCommentBoardCards) {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to send scheduled comment"))
+		return
+	}
+
+	comment, err := a.app.SendScheduledCommentNow(blockID, userID)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	data, err := json.Marshal(comment)
+	if err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
+	jsonBytesResponse(w, http.StatusOK, data)
+
+	auditRec := a.makeAuditRecord(r, "sendScheduledCommentNow", audit.Fail)
+	auditRec.AddMeta("boardID", boardID)
+	auditRec.AddMeta("blockID", blockID)
+	auditRec.Success()
+	a.audit.LogRecord(audit.LevelModify, auditRec)
+}

--- a/server/app/scheduled_comments.go
+++ b/server/app/scheduled_comments.go
@@ -1,0 +1,376 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
+	"github.com/mattermost/mattermost-plugin-boards/server/services/notify"
+	"github.com/mattermost/mattermost-plugin-boards/server/utils"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// ProcessScheduledComments processes all scheduled comments that are due to be sent.
+// This method is called periodically by the scheduler.
+func (a *App) ProcessScheduledComments() error {
+	now := model.GetMillis()
+
+	comments, err := a.store.GetScheduledComments(now)
+	if err != nil {
+		return err
+	}
+
+	if len(comments) == 0 {
+		return nil
+	}
+
+	a.logger.Debug("Processing scheduled comments",
+		mlog.Int("count", len(comments)),
+	)
+
+	for _, comment := range comments {
+		if err := a.sendScheduledComment(comment); err != nil {
+			a.logger.Error("Failed to send scheduled comment",
+				mlog.String("blockID", comment.ID),
+				mlog.String("boardID", comment.BoardID),
+				mlog.String("cardID", comment.ParentID),
+				mlog.Err(err),
+			)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// sendScheduledComment marks a comment as sent and triggers notifications.
+func (a *App) sendScheduledComment(comment *model.Block) error {
+	// Update status to sent
+	patch := &model.BlockPatch{
+		UpdatedFields: map[string]interface{}{
+			model.BlockFieldScheduledStatus: model.ScheduledStatusSent,
+		},
+	}
+
+	// Use PatchBlockAndNotify to trigger mentions
+	updatedComment, err := a.PatchBlockAndNotify(comment.ID, patch, comment.CreatedBy, false)
+	if err != nil {
+		return err
+	}
+
+	// Get board for WebSocket broadcast
+	board, err := a.store.GetBoard(comment.BoardID)
+	if err != nil {
+		a.logger.Warn("Failed to get board for scheduled comment",
+			mlog.String("boardID", comment.BoardID),
+			mlog.Err(err),
+		)
+		// Continue anyway - the comment is already updated
+	}
+
+	// Broadcast via WebSocket
+	if board != nil {
+		a.blockChangeNotifier.Enqueue(func() error {
+			a.wsAdapter.BroadcastBlockChange(board.TeamID, updatedComment)
+			return nil
+		})
+	}
+
+	// Trigger notifications for mentions in the comment
+	a.notifyBlockChanged(notify.Add, updatedComment, nil, comment.CreatedBy)
+
+	// Post notification to linked channel if exists
+	if board != nil && board.ChannelID != "" {
+		a.postScheduledCommentNotification(board, comment)
+	}
+
+	a.logger.Info("Scheduled comment sent",
+		mlog.String("blockID", comment.ID),
+		mlog.String("boardID", comment.BoardID),
+		mlog.String("cardID", comment.ParentID),
+		mlog.String("createdBy", comment.CreatedBy),
+	)
+
+	return nil
+}
+
+// postScheduledCommentNotification posts a notification to the linked channel.
+func (a *App) postScheduledCommentNotification(board *model.Board, comment *model.Block) {
+	card, err := a.store.GetBlock(comment.ParentID)
+	if err != nil || card == nil {
+		a.logger.Warn("Failed to get card for scheduled comment notification",
+			mlog.String("cardID", comment.ParentID),
+			mlog.Err(err),
+		)
+		return
+	}
+
+	user, err := a.store.GetUserByID(comment.CreatedBy)
+	if err != nil || user == nil {
+		a.logger.Warn("Failed to get user for scheduled comment notification",
+			mlog.String("userID", comment.CreatedBy),
+			mlog.Err(err),
+		)
+		return
+	}
+
+	cardLink := utils.MakeCardLink(a.config.ServerRoot, board.TeamID, board.ID, card.ID)
+	message := fmt.Sprintf("📝 **%s** commented on [%s](%s):\n> %s",
+		user.Username,
+		card.Title,
+		cardLink,
+		comment.Title,
+	)
+
+	if err := a.store.PostMessage(message, "", board.ChannelID); err != nil {
+		a.logger.Error("Failed to post scheduled comment notification to channel",
+			mlog.String("channelID", board.ChannelID),
+			mlog.Err(err),
+		)
+	}
+}
+
+// CreateScheduledComment creates a new scheduled comment with validation.
+func (a *App) CreateScheduledComment(boardID, cardID, userID, title string, scheduledAt int64) (*model.Block, error) {
+	// Validate scheduled time
+	now := model.GetMillis()
+	minScheduleTime := now + (60 * 1000) // At least 1 minute in the future
+
+	if scheduledAt < minScheduleTime {
+		return nil, model.NewErrBadRequest("scheduled time must be at least 1 minute in the future")
+	}
+
+	maxScheduleTime := now + (int64(model.MaxScheduleDays) * 24 * 60 * 60 * 1000)
+	if scheduledAt > maxScheduleTime {
+		return nil, model.NewErrBadRequest("scheduled time cannot be more than 30 days in the future")
+	}
+
+	// Check user's scheduled comments limit
+	count, err := a.store.GetScheduledCommentsCountByUser(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if count >= model.MaxScheduledCommentsPerUser {
+		return nil, model.NewErrBadRequest("maximum scheduled comments limit reached")
+	}
+
+	// Create the comment block
+	comment := &model.Block{
+		ID:        utils.NewID(utils.IDTypeBlock),
+		ParentID:  cardID,
+		BoardID:   boardID,
+		Type:      model.TypeComment,
+		Title:     title,
+		CreatedBy: userID,
+		CreateAt:  now,
+		UpdateAt:  now,
+		Fields: map[string]interface{}{
+			model.BlockFieldScheduledAt:     scheduledAt,
+			model.BlockFieldScheduledStatus: model.ScheduledStatusPending,
+		},
+	}
+
+	if err := a.store.InsertBlock(comment, userID); err != nil {
+		return nil, err
+	}
+
+	a.metrics.IncrementBlocksInserted(1)
+
+	// Get board for WebSocket broadcast
+	board, err := a.store.GetBoard(boardID)
+	if err != nil {
+		a.logger.Warn("Failed to get board for scheduled comment",
+			mlog.String("boardID", boardID),
+			mlog.Err(err),
+		)
+	}
+
+	// Broadcast the new scheduled comment via WebSocket
+	if board != nil {
+		a.blockChangeNotifier.Enqueue(func() error {
+			a.wsAdapter.BroadcastBlockChange(board.TeamID, comment)
+			return nil
+		})
+	}
+
+	a.logger.Info("Scheduled comment created",
+		mlog.String("blockID", comment.ID),
+		mlog.String("boardID", boardID),
+		mlog.String("cardID", cardID),
+		mlog.String("userID", userID),
+		mlog.String("scheduledAt", formatScheduledTime(scheduledAt)),
+	)
+
+	return comment, nil
+}
+
+// CancelScheduledComment cancels a scheduled comment.
+func (a *App) CancelScheduledComment(blockID, userID string) (*model.Block, error) {
+	block, err := a.store.GetBlock(blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	if block == nil {
+		return nil, model.NewErrNotFound("block not found")
+	}
+
+	// Verify it's a comment
+	if block.Type != model.TypeComment {
+		return nil, model.NewErrBadRequest("block is not a comment")
+	}
+
+	// Verify it's a pending scheduled comment
+	status, _ := block.Fields[model.BlockFieldScheduledStatus].(string)
+	if status != model.ScheduledStatusPending {
+		return nil, model.NewErrBadRequest("comment is not scheduled or already sent")
+	}
+
+	// Verify ownership - only creator can cancel
+	if block.CreatedBy != userID {
+		return nil, model.NewErrForbidden("can only cancel own scheduled comments")
+	}
+
+	// Update status to cancelled
+	patch := &model.BlockPatch{
+		UpdatedFields: map[string]interface{}{
+			model.BlockFieldScheduledStatus: model.ScheduledStatusCancelled,
+		},
+	}
+
+	updatedBlock, err := a.PatchBlock(blockID, patch, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	a.logger.Info("Scheduled comment cancelled",
+		mlog.String("blockID", blockID),
+		mlog.String("userID", userID),
+	)
+
+	return updatedBlock, nil
+}
+
+// SendScheduledCommentNow immediately sends a scheduled comment.
+func (a *App) SendScheduledCommentNow(blockID, userID string) (*model.Block, error) {
+	block, err := a.store.GetBlock(blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	if block == nil {
+		return nil, model.NewErrNotFound("block not found")
+	}
+
+	// Verify it's a comment
+	if block.Type != model.TypeComment {
+		return nil, model.NewErrBadRequest("block is not a comment")
+	}
+
+	// Verify it's a pending scheduled comment
+	status, _ := block.Fields[model.BlockFieldScheduledStatus].(string)
+	if status != model.ScheduledStatusPending {
+		return nil, model.NewErrBadRequest("comment is not scheduled or already sent")
+	}
+
+	// Verify ownership - only creator can send now
+	if block.CreatedBy != userID {
+		return nil, model.NewErrForbidden("can only send own scheduled comments")
+	}
+
+	if err := a.sendScheduledComment(block); err != nil {
+		return nil, err
+	}
+
+	// Return the updated block
+	return a.store.GetBlock(blockID)
+}
+
+// UpdateScheduledComment updates the content or scheduled time of a scheduled comment.
+func (a *App) UpdateScheduledComment(blockID, userID string, title *string, scheduledAt *int64) (*model.Block, error) {
+	block, err := a.store.GetBlock(blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	if block == nil {
+		return nil, model.NewErrNotFound("block not found")
+	}
+
+	// Verify it's a comment
+	if block.Type != model.TypeComment {
+		return nil, model.NewErrBadRequest("block is not a comment")
+	}
+
+	// Verify it's a pending scheduled comment
+	status, _ := block.Fields[model.BlockFieldScheduledStatus].(string)
+	if status != model.ScheduledStatusPending {
+		return nil, model.NewErrBadRequest("comment is not scheduled or already sent")
+	}
+
+	// Verify ownership
+	if block.CreatedBy != userID {
+		return nil, model.NewErrForbidden("can only update own scheduled comments")
+	}
+
+	patch := &model.BlockPatch{}
+
+	if title != nil {
+		patch.Title = title
+	}
+
+	if scheduledAt != nil {
+		// Validate new scheduled time
+		now := model.GetMillis()
+		minScheduleTime := now + (60 * 1000) // At least 1 minute in the future
+
+		if *scheduledAt < minScheduleTime {
+			return nil, model.NewErrBadRequest("scheduled time must be at least 1 minute in the future")
+		}
+
+		maxScheduleTime := now + (int64(model.MaxScheduleDays) * 24 * 60 * 60 * 1000)
+		if *scheduledAt > maxScheduleTime {
+			return nil, model.NewErrBadRequest("scheduled time cannot be more than 30 days in the future")
+		}
+
+		patch.UpdatedFields = map[string]interface{}{
+			model.BlockFieldScheduledAt: *scheduledAt,
+		}
+	}
+
+	return a.PatchBlock(blockID, patch, userID)
+}
+
+// GetMyScheduledComments returns all pending scheduled comments for a user.
+func (a *App) GetMyScheduledComments(userID string) ([]*model.Block, error) {
+	return a.store.GetScheduledCommentsByUser(userID)
+}
+
+// GetScheduledCommentsForCard returns scheduled comments for a card.
+// Only returns comments created by the requesting user.
+func (a *App) GetScheduledCommentsForCard(cardID, userID string) ([]*model.Block, error) {
+	comments, err := a.store.GetScheduledCommentsForCard(cardID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter to only show user's own scheduled comments
+	var result []*model.Block
+	for _, c := range comments {
+		if c.CreatedBy == userID {
+			result = append(result, c)
+		}
+	}
+
+	return result, nil
+}
+
+// formatScheduledTime formats the scheduled time for logging.
+func formatScheduledTime(scheduledAt int64) string {
+	return time.UnixMilli(scheduledAt).Format(time.RFC3339)
+}

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -23,6 +23,19 @@ const (
 	BlockFieldsMaxRunes    = 800000
 	BlockFieldFileId       = "fileId"
 	BlockFieldAttachmentId = "attachmentId"
+
+	// Scheduled comment fields
+	BlockFieldScheduledAt     = "scheduledAt"
+	BlockFieldScheduledStatus = "scheduledStatus"
+
+	// Scheduled status values
+	ScheduledStatusPending   = "pending"
+	ScheduledStatusSent      = "sent"
+	ScheduledStatusCancelled = "cancelled"
+
+	// Scheduled comment limits
+	MaxScheduledCommentsPerUser = 100
+	MaxScheduleDays             = 30
 )
 
 var (

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -43,8 +43,9 @@ import (
 )
 
 const (
-	cleanupSessionTaskFrequency = 10 * time.Minute
-	updateMetricsTaskFrequency  = 15 * time.Minute
+	cleanupSessionTaskFrequency         = 10 * time.Minute
+	updateMetricsTaskFrequency          = 15 * time.Minute
+	processScheduledCommentsFrequency   = 1 * time.Minute
 )
 
 type noOpMutexAPIAdapter struct{}
@@ -68,6 +69,7 @@ type Server struct {
 	metricsServer          *metrics.Service
 	metricsService         *metrics.Metrics
 	metricsUpdaterTask     *scheduler.ScheduledTask
+	scheduledCommentsTask  *scheduler.ScheduledTask
 	auditService           *audit.Audit
 	notificationService    *notify.Service
 	servicesStartStopMutex sync.Mutex
@@ -291,6 +293,14 @@ func (s *Server) Start() error {
 	// metricsUpdater()   Calling this immediately causes integration unit tests to fail.
 	s.metricsUpdaterTask = scheduler.CreateRecurringTask("updateMetrics", metricsUpdater, updateMetricsTaskFrequency)
 
+	// Start scheduled comments processor
+	scheduledCommentsProcessor := func() {
+		if err := s.app.ProcessScheduledComments(); err != nil {
+			s.logger.Error("Error processing scheduled comments", mlog.Err(err))
+		}
+	}
+	s.scheduledCommentsTask = scheduler.CreateRecurringTask("processScheduledComments", scheduledCommentsProcessor, processScheduledCommentsFrequency)
+
 	if s.config.Telemetry {
 		firstRun := utils.GetMillis()
 		s.telemetry.RunTelemetryJob(firstRun)
@@ -330,6 +340,10 @@ func (s *Server) Shutdown() error {
 
 	if s.metricsUpdaterTask != nil {
 		s.metricsUpdaterTask.Cancel()
+	}
+
+	if s.scheduledCommentsTask != nil {
+		s.scheduledCommentsTask.Cancel()
 	}
 
 	if err := s.telemetry.Shutdown(); err != nil {

--- a/server/services/store/sqlstore/scheduled_comments.go
+++ b/server/services/store/sqlstore/scheduled_comments.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// jsonFieldExtract returns the SQL expression to extract a string field from JSON.
+func (s *SQLStore) jsonFieldExtract(column, key string) string {
+	switch s.dbType {
+	case model.PostgresDBType:
+		return fmt.Sprintf("%s->>'%s'", column, key)
+	case model.MysqlDBType, model.SqliteDBType:
+		return fmt.Sprintf("JSON_EXTRACT(%s, '$.%s')", column, key)
+	default:
+		return fmt.Sprintf("%s->>'%s'", column, key)
+	}
+}
+
+// jsonFieldExtractInt returns the SQL expression to extract and cast an integer field from JSON.
+func (s *SQLStore) jsonFieldExtractInt(column, key string) string {
+	switch s.dbType {
+	case model.PostgresDBType:
+		return fmt.Sprintf("CAST(%s->>'%s' AS BIGINT)", column, key)
+	case model.MysqlDBType:
+		return fmt.Sprintf("CAST(JSON_UNQUOTE(JSON_EXTRACT(%s, '$.%s')) AS SIGNED)", column, key)
+	case model.SqliteDBType:
+		return fmt.Sprintf("CAST(JSON_EXTRACT(%s, '$.%s') AS INTEGER)", column, key)
+	default:
+		return fmt.Sprintf("CAST(%s->>'%s' AS BIGINT)", column, key)
+	}
+}
+
+// GetScheduledComments returns all scheduled comments that are due to be sent.
+func (s *SQLStore) GetScheduledComments(beforeTime int64) ([]*model.Block, error) {
+	return s.getScheduledComments(s.db, beforeTime)
+}
+
+func (s *SQLStore) getScheduledComments(db sq.BaseRunner, beforeTime int64) ([]*model.Block, error) {
+	scheduledAtExpr := s.jsonFieldExtractInt("fields", model.BlockFieldScheduledAt)
+	scheduledStatusExpr := s.jsonFieldExtract("fields", model.BlockFieldScheduledStatus)
+
+	query := s.getQueryBuilder(db).
+		Select(s.blockFields("")...).
+		From(s.tablePrefix + "blocks").
+		Where(sq.Eq{"type": model.TypeComment}).
+		Where(sq.Eq{"delete_at": 0}).
+		Where(sq.Eq{scheduledStatusExpr: model.ScheduledStatusPending}).
+		Where(sq.LtOrEq{scheduledAtExpr: beforeTime}).
+		OrderBy(scheduledAtExpr + " ASC")
+
+	rows, err := query.Query()
+	if err != nil {
+		s.logger.Error("GetScheduledComments error", mlog.Err(err))
+		return nil, err
+	}
+	defer s.CloseRows(rows)
+
+	return s.blocksFromRows(rows)
+}
+
+// GetScheduledCommentsByUser returns all pending scheduled comments for a specific user.
+func (s *SQLStore) GetScheduledCommentsByUser(userID string) ([]*model.Block, error) {
+	return s.getScheduledCommentsByUser(s.db, userID)
+}
+
+func (s *SQLStore) getScheduledCommentsByUser(db sq.BaseRunner, userID string) ([]*model.Block, error) {
+	scheduledAtExpr := s.jsonFieldExtractInt("fields", model.BlockFieldScheduledAt)
+	scheduledStatusExpr := s.jsonFieldExtract("fields", model.BlockFieldScheduledStatus)
+
+	query := s.getQueryBuilder(db).
+		Select(s.blockFields("")...).
+		From(s.tablePrefix + "blocks").
+		Where(sq.Eq{"type": model.TypeComment}).
+		Where(sq.Eq{"created_by": userID}).
+		Where(sq.Eq{"delete_at": 0}).
+		Where(sq.Eq{scheduledStatusExpr: model.ScheduledStatusPending}).
+		OrderBy(scheduledAtExpr + " ASC")
+
+	rows, err := query.Query()
+	if err != nil {
+		s.logger.Error("GetScheduledCommentsByUser error", mlog.Err(err), mlog.String("userID", userID))
+		return nil, err
+	}
+	defer s.CloseRows(rows)
+
+	return s.blocksFromRows(rows)
+}
+
+// GetScheduledCommentsForCard returns all pending scheduled comments for a specific card.
+func (s *SQLStore) GetScheduledCommentsForCard(cardID string) ([]*model.Block, error) {
+	return s.getScheduledCommentsForCard(s.db, cardID)
+}
+
+func (s *SQLStore) getScheduledCommentsForCard(db sq.BaseRunner, cardID string) ([]*model.Block, error) {
+	scheduledAtExpr := s.jsonFieldExtractInt("fields", model.BlockFieldScheduledAt)
+	scheduledStatusExpr := s.jsonFieldExtract("fields", model.BlockFieldScheduledStatus)
+
+	query := s.getQueryBuilder(db).
+		Select(s.blockFields("")...).
+		From(s.tablePrefix + "blocks").
+		Where(sq.Eq{"type": model.TypeComment}).
+		Where(sq.Eq{"parent_id": cardID}).
+		Where(sq.Eq{"delete_at": 0}).
+		Where(sq.Eq{scheduledStatusExpr: model.ScheduledStatusPending}).
+		OrderBy(scheduledAtExpr + " ASC")
+
+	rows, err := query.Query()
+	if err != nil {
+		s.logger.Error("GetScheduledCommentsForCard error", mlog.Err(err), mlog.String("cardID", cardID))
+		return nil, err
+	}
+	defer s.CloseRows(rows)
+
+	return s.blocksFromRows(rows)
+}
+
+// GetScheduledCommentsCountByUser returns the count of pending scheduled comments for a specific user.
+func (s *SQLStore) GetScheduledCommentsCountByUser(userID string) (int, error) {
+	return s.getScheduledCommentsCountByUser(s.db, userID)
+}
+
+func (s *SQLStore) getScheduledCommentsCountByUser(db sq.BaseRunner, userID string) (int, error) {
+	scheduledStatusExpr := s.jsonFieldExtract("fields", model.BlockFieldScheduledStatus)
+
+	query := s.getQueryBuilder(db).
+		Select("COUNT(*)").
+		From(s.tablePrefix + "blocks").
+		Where(sq.Eq{"type": model.TypeComment}).
+		Where(sq.Eq{"created_by": userID}).
+		Where(sq.Eq{"delete_at": 0}).
+		Where(sq.Eq{scheduledStatusExpr: model.ScheduledStatusPending})
+
+	row := query.QueryRow()
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		s.logger.Error("GetScheduledCommentsCountByUser error", mlog.Err(err), mlog.String("userID", userID))
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/server/services/store/store.go
+++ b/server/services/store/store.go
@@ -184,6 +184,12 @@ type Store interface {
 	// For unit testing only
 	DeleteBoardRecord(boardID, modifiedBy string) error
 	DeleteBlockRecord(blockID, modifiedBy string) error
+
+	// Scheduled comments
+	GetScheduledComments(beforeTime int64) ([]*model.Block, error)
+	GetScheduledCommentsByUser(userID string) ([]*model.Block, error)
+	GetScheduledCommentsForCard(cardID string) ([]*model.Block, error)
+	GetScheduledCommentsCountByUser(userID string) (int, error)
 }
 
 type NotSupportedError struct {

--- a/spec-docs/scheduled-comments.md
+++ b/spec-docs/scheduled-comments.md
@@ -1,0 +1,974 @@
+# 댓글 예약 발송 기능 설계
+
+## 개요
+
+카드 댓글에 예약 발송 기능을 추가하여 지정된 시간에 자동으로 댓글이 게시되도록 합니다.
+
+### 목표
+- 사용자가 특정 날짜/시간에 댓글이 자동 게시되도록 예약
+- 예약된 댓글 조회, 수정, 취소 기능
+- 예약 시간 도달 시 @멘션 알림 트리거
+
+### 비목표
+- 반복 예약 (매주, 매일 등)
+- 다른 블록 타입의 예약 발송
+
+---
+
+## 아키텍처
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        Frontend                               │
+│  ┌─────────────────┐    ┌─────────────────────────────┐      │
+│  │ CommentsList    │───▶│ ScheduledCommentPicker      │      │
+│  │ (예약 버튼 추가)│    │ (날짜/시간 선택 UI)         │      │
+│  └─────────────────┘    └─────────────────────────────┘      │
+└───────────────────────────────┬──────────────────────────────┘
+                                │
+                    POST /blocks (with scheduledAt field)
+                                │
+┌───────────────────────────────▼──────────────────────────────┐
+│                        Backend                                │
+│  ┌─────────────────┐    ┌─────────────────────────────┐      │
+│  │ API Handler     │───▶│ App Layer                   │      │
+│  │ (예약 댓글 API) │    │ (예약 댓글 조회/발송)       │      │
+│  └─────────────────┘    └──────────────┬──────────────┘      │
+│                                        │                      │
+│  ┌─────────────────┐    ┌──────────────▼──────────────┐      │
+│  │ Scheduler       │───▶│ Store (예약 댓글 쿼리)      │      │
+│  │ (1분 주기 체크) │    │                             │      │
+│  └─────────────────┘    └─────────────────────────────┘      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 데이터 모델
+
+### 접근 방식
+
+댓글은 기존 `Block` 타입(`type: 'comment'`)으로 구현되어 있으므로, `Block.Fields`에 예약 정보를 저장합니다.
+
+### Block.Fields 확장
+
+```go
+// 예약 관련 필드 상수 (server/model/block.go)
+const (
+    BlockFieldScheduledAt     = "scheduledAt"     // Unix 밀리초 타임스탬프
+    BlockFieldScheduledStatus = "scheduledStatus" // pending | sent | cancelled
+)
+```
+
+```json
+{
+  "id": "comment_block_id",
+  "type": "comment",
+  "parentId": "card_id",
+  "boardId": "board_id",
+  "title": "예약된 댓글 내용",
+  "fields": {
+    "scheduledAt": 1706700000000,
+    "scheduledStatus": "pending"
+  },
+  "createdBy": "user_id",
+  "createAt": 1706600000000,
+  "updateAt": 1706600000000,
+  "deleteAt": 0
+}
+```
+
+### 예약 상태 (scheduledStatus)
+
+| 상태 | 설명 |
+|------|------|
+| `pending` | 예약됨, 발송 대기 중 |
+| `sent` | 발송 완료 |
+| `cancelled` | 예약 취소됨 |
+
+### 예약된 댓글 조회 조건
+
+예약된 댓글(아직 발송되지 않은)은 일반 댓글 목록에서 제외합니다:
+
+```sql
+-- 일반 댓글 조회 (기존 로직 수정)
+SELECT * FROM focalboard_blocks
+WHERE type = 'comment'
+  AND parent_id = :cardId
+  AND delete_at = 0
+  AND (
+    fields->>'scheduledStatus' IS NULL 
+    OR fields->>'scheduledStatus' = 'sent'
+  )
+ORDER BY create_at DESC;
+
+-- 예약된 댓글 조회 (새로운 쿼리)
+SELECT * FROM focalboard_blocks
+WHERE type = 'comment'
+  AND parent_id = :cardId
+  AND delete_at = 0
+  AND fields->>'scheduledStatus' = 'pending'
+ORDER BY CAST(fields->>'scheduledAt' AS BIGINT) ASC;
+```
+
+---
+
+## API 설계
+
+### 기존 API 동작 변경
+
+#### POST /api/v2/boards/{boardID}/blocks
+
+예약 댓글 생성 시 `fields`에 예약 정보 포함:
+
+```json
+{
+  "type": "comment",
+  "parentId": "{cardId}",
+  "title": "댓글 내용",
+  "fields": {
+    "scheduledAt": 1706700000000,
+    "scheduledStatus": "pending"
+  }
+}
+```
+
+### 새로운 API 엔드포인트
+
+#### GET /api/v2/me/scheduled-comments
+
+현재 사용자의 모든 예약된 댓글 조회
+
+**Response:**
+```json
+{
+  "comments": [
+    {
+      "id": "block_id",
+      "type": "comment",
+      "parentId": "card_id",
+      "boardId": "board_id",
+      "title": "댓글 내용",
+      "fields": {
+        "scheduledAt": 1706700000000,
+        "scheduledStatus": "pending"
+      },
+      "createAt": 1706600000000,
+      "card": {
+        "id": "card_id",
+        "title": "카드 제목"
+      },
+      "board": {
+        "id": "board_id",
+        "title": "보드 제목"
+      }
+    }
+  ]
+}
+```
+
+#### DELETE /api/v2/boards/{boardID}/blocks/{blockID}/schedule
+
+예약 취소 (scheduledStatus를 cancelled로 변경)
+
+**Response:**
+```json
+{
+  "id": "block_id",
+  "fields": {
+    "scheduledAt": 1706700000000,
+    "scheduledStatus": "cancelled"
+  }
+}
+```
+
+#### POST /api/v2/boards/{boardID}/blocks/{blockID}/send-now
+
+예약된 댓글 즉시 발송
+
+**Response:**
+```json
+{
+  "id": "block_id",
+  "fields": {
+    "scheduledAt": 1706700000000,
+    "scheduledStatus": "sent"
+  }
+}
+```
+
+---
+
+## 서버 구현
+
+### Phase 1: 데이터 모델
+
+#### 1-1. Block 필드 상수 추가
+
+**파일:** `server/model/block.go`
+
+```go
+const (
+    // 기존 상수들...
+    BlockFieldScheduledAt     = "scheduledAt"
+    BlockFieldScheduledStatus = "scheduledStatus"
+)
+
+// 예약 상태 상수
+const (
+    ScheduledStatusPending   = "pending"
+    ScheduledStatusSent      = "sent"
+    ScheduledStatusCancelled = "cancelled"
+)
+```
+
+### Phase 2: Store 레이어
+
+#### 2-1. Store 인터페이스 추가
+
+**파일:** `server/services/store/store.go`
+
+```go
+type Store interface {
+    // 기존 메서드들...
+    
+    // 예약 댓글 관련
+    GetScheduledComments(beforeTime int64) ([]*model.Block, error)
+    GetScheduledCommentsByUser(userID string) ([]*model.Block, error)
+    GetScheduledCommentsForCard(cardID string) ([]*model.Block, error)
+}
+```
+
+#### 2-2. SQLStore 구현
+
+**파일:** `server/services/store/sqlstore/scheduled_comments.go` (새 파일)
+
+```go
+package sqlstore
+
+import (
+    "github.com/mattermost/mattermost-plugin-boards/server/model"
+    sq "github.com/Masterminds/squirrel"
+)
+
+// GetScheduledComments returns all scheduled comments that should be sent
+func (s *SQLStore) GetScheduledComments(beforeTime int64) ([]*model.Block, error) {
+    query := s.getQueryBuilder().
+        Select(s.blockFields("")...).
+        From(s.tablePrefix + "blocks").
+        Where(sq.Eq{"type": model.TypeComment}).
+        Where(sq.Eq{"delete_at": 0}).
+        Where(sq.Eq{s.jsonExtract("fields", "scheduledStatus"): model.ScheduledStatusPending}).
+        Where(sq.LtOrEq{s.jsonExtractInt("fields", "scheduledAt"): beforeTime})
+    
+    rows, err := query.Query()
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+    
+    return s.blocksFromRows(rows)
+}
+
+// GetScheduledCommentsByUser returns all pending scheduled comments for a user
+func (s *SQLStore) GetScheduledCommentsByUser(userID string) ([]*model.Block, error) {
+    query := s.getQueryBuilder().
+        Select(s.blockFields("")...).
+        From(s.tablePrefix + "blocks").
+        Where(sq.Eq{"type": model.TypeComment}).
+        Where(sq.Eq{"created_by": userID}).
+        Where(sq.Eq{"delete_at": 0}).
+        Where(sq.Eq{s.jsonExtract("fields", "scheduledStatus"): model.ScheduledStatusPending}).
+        OrderBy(s.jsonExtractInt("fields", "scheduledAt") + " ASC")
+    
+    rows, err := query.Query()
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+    
+    return s.blocksFromRows(rows)
+}
+
+// GetScheduledCommentsForCard returns pending scheduled comments for a card
+func (s *SQLStore) GetScheduledCommentsForCard(cardID string) ([]*model.Block, error) {
+    query := s.getQueryBuilder().
+        Select(s.blockFields("")...).
+        From(s.tablePrefix + "blocks").
+        Where(sq.Eq{"type": model.TypeComment}).
+        Where(sq.Eq{"parent_id": cardID}).
+        Where(sq.Eq{"delete_at": 0}).
+        Where(sq.Eq{s.jsonExtract("fields", "scheduledStatus"): model.ScheduledStatusPending}).
+        OrderBy(s.jsonExtractInt("fields", "scheduledAt") + " ASC")
+    
+    rows, err := query.Query()
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+    
+    return s.blocksFromRows(rows)
+}
+```
+
+### Phase 3: App 레이어
+
+**파일:** `server/app/scheduled_comments.go` (새 파일)
+
+```go
+package app
+
+import (
+    "github.com/mattermost/mattermost-plugin-boards/server/model"
+    "github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// ProcessScheduledComments processes all scheduled comments that are due
+func (a *App) ProcessScheduledComments() error {
+    now := model.GetMillis()
+    
+    comments, err := a.store.GetScheduledComments(now)
+    if err != nil {
+        return err
+    }
+    
+    a.logger.Debug("Processing scheduled comments",
+        mlog.Int("count", len(comments)),
+    )
+    
+    for _, comment := range comments {
+        if err := a.sendScheduledComment(comment); err != nil {
+            a.logger.Error("Failed to send scheduled comment",
+                mlog.String("blockID", comment.ID),
+                mlog.Err(err),
+            )
+            continue
+        }
+    }
+    
+    return nil
+}
+
+// sendScheduledComment marks a comment as sent and triggers notifications
+func (a *App) sendScheduledComment(comment *model.Block) error {
+    // Update status to sent
+    patch := &model.BlockPatch{
+        UpdatedFields: map[string]interface{}{
+            model.BlockFieldScheduledStatus: model.ScheduledStatusSent,
+        },
+    }
+    
+    updatedComment, err := a.PatchBlockAndNotify(
+        comment.ID,
+        patch,
+        comment.CreatedBy,
+        false, // disableNotify = false to trigger mentions
+    )
+    if err != nil {
+        return err
+    }
+    
+    // Broadcast via WebSocket
+    a.blockChangeNotifier.Enqueue(func() error {
+        a.wsAdapter.BroadcastBlockChange(comment.BoardID, *updatedComment)
+        return nil
+    })
+    
+    a.logger.Info("Scheduled comment sent",
+        mlog.String("blockID", comment.ID),
+        mlog.String("boardID", comment.BoardID),
+        mlog.String("cardID", comment.ParentID),
+    )
+    
+    return nil
+}
+
+// CancelScheduledComment cancels a scheduled comment
+func (a *App) CancelScheduledComment(blockID, userID string) (*model.Block, error) {
+    block, err := a.GetBlockByID(blockID)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Verify it's a scheduled comment
+    if block.Type != model.TypeComment {
+        return nil, model.NewErrBadRequest("block is not a comment")
+    }
+    
+    status, _ := block.Fields[model.BlockFieldScheduledStatus].(string)
+    if status != model.ScheduledStatusPending {
+        return nil, model.NewErrBadRequest("comment is not scheduled or already sent")
+    }
+    
+    // Verify ownership
+    if block.CreatedBy != userID {
+        return nil, model.NewErrForbidden("can only cancel own scheduled comments")
+    }
+    
+    patch := &model.BlockPatch{
+        UpdatedFields: map[string]interface{}{
+            model.BlockFieldScheduledStatus: model.ScheduledStatusCancelled,
+        },
+    }
+    
+    return a.PatchBlock(blockID, patch, userID)
+}
+
+// SendScheduledCommentNow immediately sends a scheduled comment
+func (a *App) SendScheduledCommentNow(blockID, userID string) (*model.Block, error) {
+    block, err := a.GetBlockByID(blockID)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Verify it's a pending scheduled comment
+    if block.Type != model.TypeComment {
+        return nil, model.NewErrBadRequest("block is not a comment")
+    }
+    
+    status, _ := block.Fields[model.BlockFieldScheduledStatus].(string)
+    if status != model.ScheduledStatusPending {
+        return nil, model.NewErrBadRequest("comment is not scheduled")
+    }
+    
+    // Verify ownership
+    if block.CreatedBy != userID {
+        return nil, model.NewErrForbidden("can only send own scheduled comments")
+    }
+    
+    if err := a.sendScheduledComment(block); err != nil {
+        return nil, err
+    }
+    
+    return a.GetBlockByID(blockID)
+}
+
+// GetMyScheduledComments returns all scheduled comments for a user
+func (a *App) GetMyScheduledComments(userID string) ([]*model.Block, error) {
+    return a.store.GetScheduledCommentsByUser(userID)
+}
+
+// GetScheduledCommentsForCard returns scheduled comments for a card visible to user
+func (a *App) GetScheduledCommentsForCard(cardID, userID string) ([]*model.Block, error) {
+    comments, err := a.store.GetScheduledCommentsForCard(cardID)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Filter to only show user's own scheduled comments
+    var result []*model.Block
+    for _, c := range comments {
+        if c.CreatedBy == userID {
+            result = append(result, c)
+        }
+    }
+    
+    return result, nil
+}
+```
+
+### Phase 4: 스케줄러 등록
+
+**파일:** `server/boards/boardsapp.go` 수정
+
+```go
+func (b *BoardsApp) Start() error {
+    // 기존 시작 로직...
+    
+    // 예약 댓글 처리 스케줄러 (1분 주기)
+    b.scheduledCommentsTask = scheduler.CreateRecurringTask(
+        "ProcessScheduledComments",
+        func() {
+            if err := b.server.App().ProcessScheduledComments(); err != nil {
+                b.logger.Error("Failed to process scheduled comments", mlog.Err(err))
+            }
+        },
+        time.Minute,
+    )
+    
+    return nil
+}
+
+func (b *BoardsApp) Stop() error {
+    // 기존 중지 로직...
+    
+    if b.scheduledCommentsTask != nil {
+        b.scheduledCommentsTask.Cancel()
+    }
+    
+    return nil
+}
+```
+
+### Phase 5: API 핸들러
+
+**파일:** `server/api/scheduled_comments.go` (새 파일)
+
+```go
+package api
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "github.com/gorilla/mux"
+    "github.com/mattermost/mattermost-plugin-boards/server/model"
+)
+
+func (a *API) registerScheduledCommentsRoutes(r *mux.Router) {
+    // 내 예약 댓글 목록
+    r.HandleFunc("/me/scheduled-comments", a.sessionRequired(a.handleGetMyScheduledComments)).Methods(http.MethodGet)
+    
+    // 예약 취소
+    r.HandleFunc("/boards/{boardID}/blocks/{blockID}/schedule", a.sessionRequired(a.handleCancelScheduledComment)).Methods(http.MethodDelete)
+    
+    // 즉시 발송
+    r.HandleFunc("/boards/{boardID}/blocks/{blockID}/send-now", a.sessionRequired(a.handleSendScheduledCommentNow)).Methods(http.MethodPost)
+}
+
+func (a *API) handleGetMyScheduledComments(w http.ResponseWriter, r *http.Request) {
+    userID := getUserID(r)
+    
+    comments, err := a.app.GetMyScheduledComments(userID)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    data, err := json.Marshal(comments)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    jsonBytesResponse(w, http.StatusOK, data)
+}
+
+func (a *API) handleCancelScheduledComment(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    blockID := vars["blockID"]
+    userID := getUserID(r)
+    
+    block, err := a.app.CancelScheduledComment(blockID, userID)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    data, err := json.Marshal(block)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    jsonBytesResponse(w, http.StatusOK, data)
+}
+
+func (a *API) handleSendScheduledCommentNow(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    blockID := vars["blockID"]
+    userID := getUserID(r)
+    
+    block, err := a.app.SendScheduledCommentNow(blockID, userID)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    data, err := json.Marshal(block)
+    if err != nil {
+        a.errorResponse(w, r, err)
+        return
+    }
+    
+    jsonBytesResponse(w, http.StatusOK, data)
+}
+```
+
+---
+
+## 프론트엔드 구현
+
+### Phase 1: 타입 정의
+
+**파일:** `webapp/src/blocks/commentBlock.ts`
+
+```typescript
+import {Block, createBlock} from './block'
+
+// 예약 상태
+export type ScheduledStatus = 'pending' | 'sent' | 'cancelled'
+
+// 예약 댓글 필드
+export interface ScheduledCommentFields {
+    scheduledAt?: number      // Unix 밀리초
+    scheduledStatus?: ScheduledStatus
+}
+
+type CommentBlock = Block & {
+    type: 'comment'
+    fields: ScheduledCommentFields
+}
+
+function createCommentBlock(block?: Block): CommentBlock {
+    return {
+        ...createBlock(block),
+        type: 'comment',
+        fields: block?.fields || {},
+    }
+}
+
+function createScheduledCommentBlock(
+    block: Partial<Block>,
+    scheduledAt: number
+): CommentBlock {
+    return {
+        ...createCommentBlock(block as Block),
+        fields: {
+            scheduledAt,
+            scheduledStatus: 'pending',
+        },
+    }
+}
+
+function isScheduledComment(block: Block): boolean {
+    return block.type === 'comment' && 
+           block.fields?.scheduledStatus === 'pending'
+}
+
+function isSentComment(block: Block): boolean {
+    return block.type === 'comment' && 
+           (!block.fields?.scheduledStatus || 
+            block.fields?.scheduledStatus === 'sent')
+}
+
+export {
+    CommentBlock,
+    createCommentBlock,
+    createScheduledCommentBlock,
+    isScheduledComment,
+    isSentComment,
+}
+```
+
+### Phase 2: API 클라이언트
+
+**파일:** `webapp/src/octoClient.ts` 추가
+
+```typescript
+// 내 예약 댓글 목록
+async getMyScheduledComments(): Promise<Block[]> {
+    const response = await fetch(
+        `${this.serverUrl}/api/v2/me/scheduled-comments`,
+        {headers: this.headers()}
+    )
+    if (response.status !== 200) {
+        return []
+    }
+    return (await this.getJson(response)) as Block[]
+}
+
+// 예약 취소
+async cancelScheduledComment(boardId: string, blockId: string): Promise<Block | undefined> {
+    const response = await fetch(
+        `${this.serverUrl}/api/v2/boards/${boardId}/blocks/${blockId}/schedule`,
+        {
+            method: 'DELETE',
+            headers: this.headers(),
+        }
+    )
+    if (response.status !== 200) {
+        return undefined
+    }
+    return (await this.getJson(response)) as Block
+}
+
+// 즉시 발송
+async sendScheduledCommentNow(boardId: string, blockId: string): Promise<Block | undefined> {
+    const response = await fetch(
+        `${this.serverUrl}/api/v2/boards/${boardId}/blocks/${blockId}/send-now`,
+        {
+            method: 'POST',
+            headers: this.headers(),
+        }
+    )
+    if (response.status !== 200) {
+        return undefined
+    }
+    return (await this.getJson(response)) as Block
+}
+```
+
+### Phase 3: UI 컴포넌트
+
+#### 3-1. 날짜/시간 선택기
+
+**파일:** `webapp/src/components/cardDetail/scheduledCommentPicker.tsx` (새 파일)
+
+```tsx
+import React, {useState, useCallback} from 'react'
+import {useIntl} from 'react-intl'
+
+import Button from '../../widgets/buttons/button'
+import './scheduledCommentPicker.scss'
+
+type Props = {
+    onSchedule: (scheduledAt: number) => void
+    onCancel: () => void
+}
+
+const ScheduledCommentPicker: React.FC<Props> = ({onSchedule, onCancel}) => {
+    const intl = useIntl()
+    
+    // 기본값: 내일 오전 9시
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    tomorrow.setHours(9, 0, 0, 0)
+    
+    const [date, setDate] = useState(tomorrow.toISOString().split('T')[0])
+    const [time, setTime] = useState('09:00')
+    
+    const handleSchedule = useCallback(() => {
+        const scheduledDate = new Date(`${date}T${time}`)
+        onSchedule(scheduledDate.getTime())
+    }, [date, time, onSchedule])
+    
+    const minDate = new Date().toISOString().split('T')[0]
+    
+    return (
+        <div className='ScheduledCommentPicker'>
+            <div className='ScheduledCommentPicker__header'>
+                {intl.formatMessage({
+                    id: 'ScheduledCommentPicker.title',
+                    defaultMessage: 'Schedule comment'
+                })}
+            </div>
+            
+            <div className='ScheduledCommentPicker__inputs'>
+                <input
+                    type='date'
+                    value={date}
+                    min={minDate}
+                    onChange={(e) => setDate(e.target.value)}
+                />
+                <input
+                    type='time'
+                    value={time}
+                    onChange={(e) => setTime(e.target.value)}
+                />
+            </div>
+            
+            <div className='ScheduledCommentPicker__actions'>
+                <Button onClick={onCancel}>
+                    {intl.formatMessage({
+                        id: 'ScheduledCommentPicker.cancel',
+                        defaultMessage: 'Cancel'
+                    })}
+                </Button>
+                <Button
+                    filled={true}
+                    onClick={handleSchedule}
+                >
+                    {intl.formatMessage({
+                        id: 'ScheduledCommentPicker.schedule',
+                        defaultMessage: 'Schedule'
+                    })}
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export default React.memo(ScheduledCommentPicker)
+```
+
+#### 3-2. CommentsList 수정
+
+**파일:** `webapp/src/components/cardDetail/commentsList.tsx` 수정
+
+주요 변경사항:
+- 예약 버튼 추가
+- 예약된 댓글 별도 섹션 표시
+- 발송/취소 핸들러
+
+```tsx
+// 새로운 상태
+const [showSchedulePicker, setShowSchedulePicker] = useState(false)
+
+// 예약 발송 핸들러
+const onScheduleClicked = (scheduledAt: number) => {
+    const {cardId, boardId} = props
+    const comment = createScheduledCommentBlock(
+        {parentId: cardId, boardId, title: newComment},
+        scheduledAt
+    )
+    mutator.insertBlock(boardId, comment, 'schedule comment')
+    setNewComment('')
+    setShowSchedulePicker(false)
+}
+
+// UI에 예약 버튼 추가
+{newComment && (
+    <>
+        <Button onClick={() => setShowSchedulePicker(true)}>
+            <ClockIcon />
+        </Button>
+        <Button filled={true} onClick={onSendClicked}>
+            Send
+        </Button>
+    </>
+)}
+
+{showSchedulePicker && (
+    <ScheduledCommentPicker
+        onSchedule={onScheduleClicked}
+        onCancel={() => setShowSchedulePicker(false)}
+    />
+)}
+```
+
+#### 3-3. 예약된 댓글 컴포넌트
+
+**파일:** `webapp/src/components/cardDetail/scheduledComment.tsx` (새 파일)
+
+예약된 댓글 표시 및 취소/즉시 발송 기능
+
+---
+
+## UI/UX 설계
+
+### 댓글 입력 영역
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 🖼️ | 댓글 입력 영역...                               │
+├─────────────────────────────────────────────────────┤
+│                         [🕐 예약] [전송]             │
+└─────────────────────────────────────────────────────┘
+         │
+         ▼ 클릭 시
+┌─────────────────────────────────────────────────────┐
+│ 예약 발송                                           │
+│ ┌───────────────┐  ┌───────────────┐               │
+│ │ 📅 2026-01-31 │  │ 🕐 09:00      │               │
+│ └───────────────┘  └───────────────┘               │
+│                        [취소] [예약]                 │
+└─────────────────────────────────────────────────────┘
+```
+
+### 예약된 댓글 표시
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 📋 예약된 댓글 (1)                                   │
+├─────────────────────────────────────────────────────┤
+│ 🖼️ 홍길동  •  🕐 2026-01-31 09:00 예약됨             │
+│ ─────────────────────────────────────────────────── │
+│ 예약된 댓글 내용 미리보기...                         │
+│                        [예약 취소] [지금 발송]       │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 구현 순서
+
+### 서버 (우선순위 순)
+
+1. Block 필드 상수 정의 (`server/model/block.go`)
+2. Store 인터페이스 추가 (`server/services/store/store.go`)
+3. SQLStore 구현 (`server/services/store/sqlstore/scheduled_comments.go`)
+4. App 레이어 비즈니스 로직 (`server/app/scheduled_comments.go`)
+5. API 핸들러 (`server/api/scheduled_comments.go`)
+6. API 라우트 등록 (`server/api/api.go`)
+7. 스케줄러 등록 (`server/boards/boardsapp.go`)
+8. 단위 테스트
+
+### 프론트엔드 (우선순위 순)
+
+1. CommentBlock 타입 확장 (`webapp/src/blocks/commentBlock.ts`)
+2. API 클라이언트 추가 (`webapp/src/octoClient.ts`)
+3. Redux 상태 관리 수정 (`webapp/src/store/comments.ts`)
+4. Mutator 메서드 추가 (`webapp/src/mutator.ts`)
+5. 날짜/시간 선택기 컴포넌트
+6. CommentsList 수정
+7. 예약된 댓글 컴포넌트
+8. SCSS 스타일링
+9. 단위 테스트
+
+---
+
+## 고려 사항
+
+### 시간대 처리
+
+- 서버: UTC 타임스탬프로 저장 (Unix 밀리초)
+- 프론트엔드: 사용자 로컬 시간대로 표시/입력
+- JavaScript `Date` 객체가 자동으로 로컬 ↔ UTC 변환
+
+### 권한
+
+- 기존 `PermissionCommentBoardCards` 재사용
+- 자신의 예약 댓글만 취소/즉시 발송 가능
+- Admin도 타인의 예약 댓글 취소 불가 (개인 프라이버시)
+
+### 알림
+
+- 예약 시점이 아닌 **발송 시점**에 @멘션 알림 트리거
+- 기존 `notifyMentions` 로직 재사용
+
+### 제한 사항
+
+| 항목 | 제한 |
+|------|------|
+| 최대 예약 기간 | 30일 |
+| 최소 예약 시간 | 현재 + 1분 |
+| 사용자당 예약 댓글 수 | 100개 |
+
+### WebSocket 동기화
+
+- 예약 댓글 생성/취소/발송 시 `BroadcastBlockChange` 호출
+- 다른 사용자에게는 발송 완료된 댓글만 표시
+
+---
+
+## 테스트 계획
+
+### 서버 단위 테스트
+
+- `scheduled_comments_test.go`
+  - 예약 댓글 생성
+  - 예약 시간 도달 후 발송
+  - 예약 취소
+  - 즉시 발송
+  - 권한 검증
+
+### 프론트엔드 단위 테스트
+
+- `scheduledCommentPicker.test.tsx`
+- `commentsList.test.tsx` (예약 기능 추가)
+- `scheduledComment.test.tsx`
+
+### 통합 테스트
+
+- 전체 예약 → 발송 플로우
+- WebSocket 동기화 검증
+- 시간대 변환 검증
+
+---
+
+## 마이그레이션
+
+기존 데이터에 영향 없음:
+- 새로운 `fields` 필드 추가만 필요
+- 기존 댓글은 `scheduledStatus` 없음 = 발송된 댓글로 취급
+- DB 스키마 변경 불필요
+
+---
+
+## 참고 자료
+
+- 기존 댓글 시스템: `webapp/src/components/cardDetail/commentsList.tsx`
+- Block 모델: `server/model/block.go`
+- 스케줄러: `server/services/scheduler/scheduler.go`
+- 알림 시스템: `server/services/notify/`

--- a/webapp/src/blocks/commentBlock.ts
+++ b/webapp/src/blocks/commentBlock.ts
@@ -14,4 +14,16 @@ function createCommentBlock(block?: Block): CommentBlock {
     }
 }
 
-export {CommentBlock, createCommentBlock}
+function getScheduledAt(block: Block): number | undefined {
+    return block.fields?.scheduledAt as number | undefined
+}
+
+function getScheduledStatus(block: Block): string | undefined {
+    return block.fields?.scheduledStatus as string | undefined
+}
+
+function isPendingScheduledComment(block: Block): boolean {
+    return block.type === 'comment' && block.fields?.scheduledStatus === 'pending'
+}
+
+export {CommentBlock, createCommentBlock, getScheduledAt, getScheduledStatus, isPendingScheduledComment}

--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -3,6 +3,13 @@
     flex-direction: column;
     margin: 5px 0;
 
+    &--scheduled {
+        opacity: 0.6;
+        border-left: 3px solid var(--button-bg, #166de0);
+        padding-left: 8px;
+        margin-left: -11px;
+    }
+
     &:hover {
         .MenuWrapper {
             display: block;
@@ -38,6 +45,18 @@
     .comment-date {
         color: #ccc;
         font-size: 12px;
+    }
+
+    .comment-scheduled-badge {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        color: var(--button-bg, #166de0);
+        font-weight: 500;
+    }
+
+    .comment-scheduled-icon {
+        font-size: 14px;
     }
 
     .comment-text {

--- a/webapp/src/components/cardDetail/comment.tsx
+++ b/webapp/src/components/cardDetail/comment.tsx
@@ -33,14 +33,16 @@ type Props = {
     userId: string
     userImageUrl: string
     readonly: boolean
+    scheduledAt?: number
 }
 
 const Comment: FC<Props> = (props: Props) => {
-    const {comment, userId, userImageUrl} = props
+    const {comment, userId, userImageUrl, scheduledAt} = props
     const intl = useIntl()
     const user = useAppSelector(getUser(userId))
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
     const date = new Date(comment.createAt)
+    const isScheduled = Boolean(scheduledAt)
 
     const selectedTeam = useAppSelector(getCurrentTeam)
     const channelNamesMap =  getChannelsNameMapInTeam((window as any).store.getState(), selectedTeam!.id)
@@ -56,10 +58,29 @@ const Comment: FC<Props> = (props: Props) => {
         })}
     </Provider>
 
+    const formatScheduledTime = (timestamp: number): string => {
+        const scheduledDate = new Date(timestamp)
+        const now = new Date()
+        const isToday = scheduledDate.toDateString() === now.toDateString()
+        const tomorrow = new Date(now)
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        const isTomorrow = scheduledDate.toDateString() === tomorrow.toDateString()
+        const timeStr = scheduledDate.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+
+        if (isToday) {
+            return intl.formatMessage({id: 'Comment.scheduledToday', defaultMessage: 'Scheduled for today at {time}'}, {time: timeStr})
+        }
+        if (isTomorrow) {
+            return intl.formatMessage({id: 'Comment.scheduledTomorrow', defaultMessage: 'Scheduled for tomorrow at {time}'}, {time: timeStr})
+        }
+        const dateStr = scheduledDate.toLocaleDateString([], {month: 'short', day: 'numeric'})
+        return intl.formatMessage({id: 'Comment.scheduledFor', defaultMessage: 'Scheduled for {date} at {time}'}, {date: dateStr, time: timeStr})
+    }
+
     return (
         <div
             key={comment.id}
-            className='Comment comment'
+            className={`Comment comment${isScheduled ? ' Comment--scheduled' : ''}`}
         >
             <div className='comment-header'>
                 <img
@@ -69,11 +90,20 @@ const Comment: FC<Props> = (props: Props) => {
                 <div className='comment-username'>{user ? Utils.getUserDisplayName(user, clientConfig.teammateNameDisplay) : ''}</div>
                 <GuestBadge show={user?.is_guest}/>
 
-                <Tooltip title={Utils.displayDateTime(date, intl)}>
-                    <div className='comment-date'>
-                        {Utils.relativeDisplayDateTime(date, intl)}
-                    </div>
-                </Tooltip>
+                {isScheduled ? (
+                    <Tooltip title={scheduledAt ? Utils.displayDateTime(new Date(scheduledAt), intl) : ''}>
+                        <div className='comment-date comment-scheduled-badge'>
+                            <span className='comment-scheduled-icon'>🕐</span>
+                            {scheduledAt && formatScheduledTime(scheduledAt)}
+                        </div>
+                    </Tooltip>
+                ) : (
+                    <Tooltip title={Utils.displayDateTime(date, intl)}>
+                        <div className='comment-date'>
+                            {Utils.relativeDisplayDateTime(date, intl)}
+                        </div>
+                    </Tooltip>
+                )}
 
                 {!props.readonly && (
                     <MenuWrapper>

--- a/webapp/src/components/cardDetail/commentsList.scss
+++ b/webapp/src/components/cardDetail/commentsList.scss
@@ -18,6 +18,7 @@
         align-items: flex-start;
         padding: 8px 0;
         min-height: 48px;
+        flex-wrap: wrap;
     }
 
     .newcomment {
@@ -29,8 +30,50 @@
             margin: -4px 0 0 8px;
         }
     }
+
+    .CommentsList__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin: -4px 0 0 8px;
+    }
+
+    .CommentsList__schedule-btn {
+        width: 32px;
+        height: 32px;
+        border-radius: 4px;
+
+        &:hover {
+            background: rgba(var(--center-channel-color-rgb), 0.08);
+        }
+
+        span {
+            font-size: 16px;
+        }
+    }
 }
 
 .CommentsList__divider {
     margin-top: 8px;
+}
+
+.CommentsList__scheduled {
+    margin: 8px 0 16px;
+    padding: 12px;
+    background: rgba(var(--center-channel-color-rgb), 0.04);
+    border-radius: 8px;
+
+    .CommentsList__scheduled-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-weight: 600;
+        font-size: 12px;
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+        margin-bottom: 8px;
+
+        .CompassIcon {
+            font-size: 14px;
+        }
+    }
 }

--- a/webapp/src/components/cardDetail/commentsList.tsx
+++ b/webapp/src/components/cardDetail/commentsList.tsx
@@ -4,11 +4,12 @@
 import React, {useState} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 
-import {CommentBlock, createCommentBlock} from '../../blocks/commentBlock'
+import {CommentBlock, createCommentBlock, getScheduledAt, isPendingScheduledComment} from '../../blocks/commentBlock'
 import mutator from '../../mutator'
 import {useAppSelector} from '../../store/hooks'
 import {Utils} from '../../utils'
 import Button from '../../widgets/buttons/button'
+import CompassIcon from '../../widgets/icons/compassIcon'
 
 import {MarkdownEditor} from '../markdownEditor'
 
@@ -20,6 +21,7 @@ import {Permission} from '../../constants'
 import AddCommentTourStep from '../onboardingTour/addComments/addComments'
 
 import Comment from './comment'
+import ScheduledCommentPicker from './scheduledCommentPicker'
 
 import './commentsList.scss'
 
@@ -32,13 +34,16 @@ type Props = {
 
 const CommentsList = (props: Props) => {
     const [newComment, setNewComment] = useState('')
+    const [showSchedulePicker, setShowSchedulePicker] = useState(false)
     const me = useAppSelector<IUser|null>(getMe)
     const canDeleteOthersComments = useHasCurrentBoardPermissions([Permission.DeleteOthersComments])
+    const intl = useIntl()
+
+    const {comments, boardId, cardId} = props
 
     const onSendClicked = () => {
         const commentText = newComment
         if (commentText) {
-            const {cardId, boardId} = props
             Utils.log(`Send comment: ${commentText}`)
             Utils.assertValue(cardId)
 
@@ -51,8 +56,21 @@ const CommentsList = (props: Props) => {
         }
     }
 
-    const {comments} = props
-    const intl = useIntl()
+    const onScheduleClicked = async (scheduledAt: number) => {
+        const commentText = newComment
+        if (commentText) {
+            Utils.log(`Schedule comment: ${commentText}`)
+            Utils.assertValue(cardId)
+
+            try {
+                await mutator.createScheduledComment(boardId, cardId, commentText, scheduledAt)
+                setNewComment('')
+            } catch (err) {
+                Utils.log(`Failed to schedule comment: ${err}`)
+            }
+            setShowSchedulePicker(false)
+        }
+    }
 
     const newCommentComponent = (
         <div className='CommentsList__new'>
@@ -71,17 +89,32 @@ const CommentsList = (props: Props) => {
                 }}
             />
 
-            {newComment &&
-            <Button
-                filled={true}
-                onClick={onSendClicked}
-            >
-                <FormattedMessage
-                    id='CommentsList.send'
-                    defaultMessage='Send'
+            {newComment && (
+                <div className='CommentsList__actions'>
+                    <Button
+                        onClick={() => setShowSchedulePicker(true)}
+                        title={intl.formatMessage({id: 'CommentsList.schedule', defaultMessage: 'Schedule'})}
+                    >
+                        <CompassIcon icon='clock-outline'/>
+                    </Button>
+                    <Button
+                        filled={true}
+                        onClick={onSendClicked}
+                    >
+                        <FormattedMessage
+                            id='CommentsList.send'
+                            defaultMessage='Send'
+                        />
+                    </Button>
+                </div>
+            )}
+
+            {showSchedulePicker && (
+                <ScheduledCommentPicker
+                    onSchedule={onScheduleClicked}
+                    onCancel={() => setShowSchedulePicker(false)}
                 />
-            </Button>
-            }
+            )}
 
             <AddCommentTourStep/>
         </div>
@@ -93,8 +126,10 @@ const CommentsList = (props: Props) => {
             {!props.readonly && newCommentComponent}
 
             {comments.slice(0).reverse().map((comment) => {
-                // Only modify _own_ comments, EXCEPT for Admins, which can delete _any_ comment
-                // NOTE: editing comments will exist in the future (in addition to deleting)
+                const isScheduled = isPendingScheduledComment(comment)
+                if (isScheduled && comment.createdBy !== me?.id) {
+                    return null
+                }
                 const canDeleteComment: boolean = canDeleteOthersComments || me?.id === comment.modifiedBy
                 return (
                     <Comment
@@ -103,6 +138,7 @@ const CommentsList = (props: Props) => {
                         userImageUrl={Utils.getProfilePicture(comment.modifiedBy)}
                         userId={comment.modifiedBy}
                         readonly={props.readonly || !canDeleteComment}
+                        scheduledAt={isScheduled ? getScheduledAt(comment) : undefined}
                     />
                 )
             })}

--- a/webapp/src/components/cardDetail/scheduledComment.scss
+++ b/webapp/src/components/cardDetail/scheduledComment.scss
@@ -1,0 +1,106 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+.ScheduledComment {
+    background: rgba(var(--button-bg-rgb), 0.08);
+    border: 1px dashed rgba(var(--button-bg-rgb), 0.32);
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 12px;
+
+    &__header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+    }
+
+    &__avatar {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+    &__info {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    &__username {
+        font-weight: 600;
+        font-size: 13px;
+        color: var(--center-channel-color);
+    }
+
+    &__scheduled {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 12px;
+        color: var(--button-bg);
+        font-weight: 500;
+    }
+
+    &__clock-icon {
+        font-size: 12px;
+    }
+
+    &__close {
+        opacity: 0.6;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+
+    &__content {
+        font-size: 14px;
+        color: var(--center-channel-color);
+        white-space: pre-wrap;
+        word-break: break-word;
+        padding-left: 32px;
+        margin-bottom: 8px;
+    }
+
+    &__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        padding-left: 32px;
+    }
+}
+
+.ScheduledComments {
+    margin-bottom: 16px;
+
+    &__header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        font-weight: 600;
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+        margin-bottom: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+
+        &::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: rgba(var(--center-channel-color-rgb), 0.08);
+        }
+    }
+
+    &__count {
+        background: rgba(var(--button-bg-rgb), 0.16);
+        color: var(--button-bg);
+        padding: 2px 6px;
+        border-radius: 10px;
+        font-size: 11px;
+        font-weight: 600;
+    }
+}

--- a/webapp/src/components/cardDetail/scheduledComment.tsx
+++ b/webapp/src/components/cardDetail/scheduledComment.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback} from 'react'
+import {useIntl} from 'react-intl'
+
+import {CommentBlock, getScheduledAt} from '../../blocks/commentBlock'
+import {Utils} from '../../utils'
+import {useAppSelector} from '../../store/hooks'
+import {getUser} from '../../store/users'
+import {getClientConfig} from '../../store/clientConfig'
+import {ClientConfig} from '../../config/clientConfig'
+import Button from '../../widgets/buttons/button'
+import IconButton from '../../widgets/buttons/iconButton'
+import CloseIcon from '../../widgets/icons/close'
+import Tooltip from '../../widgets/tooltip'
+import mutator from '../../mutator'
+
+import './scheduledComment.scss'
+
+type Props = {
+    comment: CommentBlock
+    boardId: string
+    readonly: boolean
+}
+
+const ScheduledComment: React.FC<Props> = ({comment, boardId, readonly}) => {
+    const intl = useIntl()
+    const user = useAppSelector(getUser(comment.createdBy))
+    const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
+
+    const scheduledAt = getScheduledAt(comment)
+    const scheduledDate = scheduledAt ? new Date(scheduledAt) : null
+
+    const handleCancel = useCallback(async () => {
+        await mutator.cancelScheduledComment(boardId, comment.id)
+    }, [boardId, comment.id])
+
+    const handleSendNow = useCallback(async () => {
+        await mutator.sendScheduledCommentNow(boardId, comment.id)
+    }, [boardId, comment.id])
+
+    const formatScheduledTime = () => {
+        if (!scheduledDate) {
+            return ''
+        }
+
+        const now = new Date()
+        const isToday = scheduledDate.toDateString() === now.toDateString()
+
+        const tomorrow = new Date(now)
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        const isTomorrow = scheduledDate.toDateString() === tomorrow.toDateString()
+
+        const timeStr = scheduledDate.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+
+        if (isToday) {
+            return intl.formatMessage(
+                {id: 'ScheduledComment.todayAt', defaultMessage: 'Today at {time}'},
+                {time: timeStr},
+            )
+        }
+
+        if (isTomorrow) {
+            return intl.formatMessage(
+                {id: 'ScheduledComment.tomorrowAt', defaultMessage: 'Tomorrow at {time}'},
+                {time: timeStr},
+            )
+        }
+
+        const dateStr = scheduledDate.toLocaleDateString([], {month: 'short', day: 'numeric'})
+        return intl.formatMessage(
+            {id: 'ScheduledComment.scheduledFor', defaultMessage: '{date} at {time}'},
+            {date: dateStr, time: timeStr},
+        )
+    }
+
+    return (
+        <div className='ScheduledComment'>
+            <div className='ScheduledComment__header'>
+                <img
+                    className='ScheduledComment__avatar'
+                    src={Utils.getProfilePicture(comment.createdBy)}
+                    alt=''
+                />
+                <div className='ScheduledComment__info'>
+                    <span className='ScheduledComment__username'>
+                        {user ? Utils.getUserDisplayName(user, clientConfig.teammateNameDisplay) : ''}
+                    </span>
+                    <Tooltip title={scheduledDate ? Utils.displayDateTime(scheduledDate, intl) : ''}>
+                        <span className='ScheduledComment__scheduled'>
+                            <span className='ScheduledComment__clock-icon'>🕐</span>
+                            {formatScheduledTime()}
+                        </span>
+                    </Tooltip>
+                </div>
+                {!readonly && (
+                    <IconButton
+                        className='ScheduledComment__close'
+                        icon={<CloseIcon/>}
+                        onClick={handleCancel}
+                        title={intl.formatMessage({
+                            id: 'ScheduledComment.cancel',
+                            defaultMessage: 'Cancel scheduled comment',
+                        })}
+                    />
+                )}
+            </div>
+
+            <div className='ScheduledComment__content'>
+                {comment.title}
+            </div>
+
+            {!readonly && (
+                <div className='ScheduledComment__actions'>
+                    <Button
+                        size='small'
+                        onClick={handleCancel}
+                    >
+                        {intl.formatMessage({
+                            id: 'ScheduledComment.cancelButton',
+                            defaultMessage: 'Cancel',
+                        })}
+                    </Button>
+                    <Button
+                        size='small'
+                        filled={true}
+                        onClick={handleSendNow}
+                    >
+                        {intl.formatMessage({
+                            id: 'ScheduledComment.sendNow',
+                            defaultMessage: 'Send now',
+                        })}
+                    </Button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default React.memo(ScheduledComment)

--- a/webapp/src/components/cardDetail/scheduledCommentPicker.scss
+++ b/webapp/src/components/cardDetail/scheduledCommentPicker.scss
@@ -1,0 +1,67 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+.ScheduledCommentPicker {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    background: var(--center-channel-bg);
+    border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+    border-radius: 4px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    padding: 16px;
+    margin-bottom: 8px;
+    z-index: 10;
+
+    &__header {
+        font-weight: 600;
+        font-size: 14px;
+        color: var(--center-channel-color);
+        margin-bottom: 12px;
+    }
+
+    &__inputs {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 12px;
+    }
+
+    &__field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+
+        label {
+            font-size: 12px;
+            color: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+
+        input {
+            padding: 8px 12px;
+            border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+            border-radius: 4px;
+            background: var(--center-channel-bg);
+            color: var(--center-channel-color);
+            font-size: 14px;
+
+            &:focus {
+                outline: none;
+                border-color: var(--button-bg);
+            }
+        }
+    }
+
+    &__error {
+        color: var(--error-text);
+        font-size: 12px;
+        margin-bottom: 12px;
+    }
+
+    &__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+    }
+}

--- a/webapp/src/components/cardDetail/scheduledCommentPicker.tsx
+++ b/webapp/src/components/cardDetail/scheduledCommentPicker.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState, useCallback, useMemo} from 'react'
+import {useIntl} from 'react-intl'
+
+import Button from '../../widgets/buttons/button'
+import './scheduledCommentPicker.scss'
+
+type Props = {
+    onSchedule: (scheduledAt: number) => void
+    onCancel: () => void
+}
+
+const ScheduledCommentPicker: React.FC<Props> = ({onSchedule, onCancel}) => {
+    const intl = useIntl()
+
+    // Default: tomorrow at 9 AM
+    const defaultDateTime = useMemo(() => {
+        const tomorrow = new Date()
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        tomorrow.setHours(9, 0, 0, 0)
+        return {
+            date: tomorrow.toISOString().split('T')[0],
+            time: '09:00',
+        }
+    }, [])
+
+    const [date, setDate] = useState(defaultDateTime.date)
+    const [time, setTime] = useState(defaultDateTime.time)
+    const [error, setError] = useState<string | null>(null)
+
+    const minDate = useMemo(() => new Date().toISOString().split('T')[0], [])
+
+    const maxDate = useMemo(() => {
+        const max = new Date()
+        max.setDate(max.getDate() + 30)
+        return max.toISOString().split('T')[0]
+    }, [])
+
+    const handleSchedule = useCallback(() => {
+        const scheduledDate = new Date(`${date}T${time}`)
+        const now = new Date()
+
+        // Validate: must be at least 1 minute in the future
+        if (scheduledDate.getTime() <= now.getTime() + 60000) {
+            setError(intl.formatMessage({
+                id: 'ScheduledCommentPicker.error.tooSoon',
+                defaultMessage: 'Scheduled time must be at least 1 minute in the future',
+            }))
+            return
+        }
+
+        // Validate: cannot be more than 30 days in the future
+        const maxTime = now.getTime() + (30 * 24 * 60 * 60 * 1000)
+        if (scheduledDate.getTime() > maxTime) {
+            setError(intl.formatMessage({
+                id: 'ScheduledCommentPicker.error.tooFar',
+                defaultMessage: 'Scheduled time cannot be more than 30 days in the future',
+            }))
+            return
+        }
+
+        setError(null)
+        onSchedule(scheduledDate.getTime())
+    }, [date, time, onSchedule, intl])
+
+    const handleDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setDate(e.target.value)
+        setError(null)
+    }, [])
+
+    const handleTimeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setTime(e.target.value)
+        setError(null)
+    }, [])
+
+    return (
+        <div className='ScheduledCommentPicker'>
+            <div className='ScheduledCommentPicker__header'>
+                {intl.formatMessage({
+                    id: 'ScheduledCommentPicker.title',
+                    defaultMessage: 'Schedule comment',
+                })}
+            </div>
+
+            <div className='ScheduledCommentPicker__inputs'>
+                <div className='ScheduledCommentPicker__field'>
+                    <label htmlFor='scheduled-date'>
+                        {intl.formatMessage({
+                            id: 'ScheduledCommentPicker.date',
+                            defaultMessage: 'Date',
+                        })}
+                    </label>
+                    <input
+                        id='scheduled-date'
+                        type='date'
+                        value={date}
+                        min={minDate}
+                        max={maxDate}
+                        onChange={handleDateChange}
+                    />
+                </div>
+                <div className='ScheduledCommentPicker__field'>
+                    <label htmlFor='scheduled-time'>
+                        {intl.formatMessage({
+                            id: 'ScheduledCommentPicker.time',
+                            defaultMessage: 'Time',
+                        })}
+                    </label>
+                    <input
+                        id='scheduled-time'
+                        type='time'
+                        value={time}
+                        onChange={handleTimeChange}
+                    />
+                </div>
+            </div>
+
+            {error && (
+                <div className='ScheduledCommentPicker__error'>
+                    {error}
+                </div>
+            )}
+
+            <div className='ScheduledCommentPicker__actions'>
+                <Button onClick={onCancel}>
+                    {intl.formatMessage({
+                        id: 'ScheduledCommentPicker.cancel',
+                        defaultMessage: 'Cancel',
+                    })}
+                </Button>
+                <Button
+                    filled={true}
+                    onClick={handleSchedule}
+                >
+                    {intl.formatMessage({
+                        id: 'ScheduledCommentPicker.schedule',
+                        defaultMessage: 'Schedule',
+                    })}
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export default React.memo(ScheduledCommentPicker)

--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -1303,6 +1303,83 @@ class Mutator {
     async redo() {
         await undoManager.redo()
     }
+
+    // ========================================
+    // Scheduled Comments
+    // ========================================
+
+    /**
+     * Create a scheduled comment
+     * Note: Scheduled comments are not undoable since they're time-sensitive
+     */
+    async createScheduledComment(
+        boardId: string,
+        cardId: string,
+        title: string,
+        scheduledAt: number,
+    ): Promise<Block | undefined> {
+        const comment = await octoClient.createScheduledComment(boardId, cardId, title, scheduledAt)
+        if (comment) {
+            store.dispatch(updateComments([comment as CommentBlock]))
+        }
+        return comment
+    }
+
+    /**
+     * Cancel a scheduled comment
+     */
+    async cancelScheduledComment(boardId: string, blockId: string): Promise<Block | undefined> {
+        const comment = await octoClient.cancelScheduledComment(boardId, blockId)
+        if (comment) {
+            store.dispatch(updateComments([comment as CommentBlock]))
+        }
+        return comment
+    }
+
+    /**
+     * Send a scheduled comment immediately
+     */
+    async sendScheduledCommentNow(boardId: string, blockId: string): Promise<Block | undefined> {
+        const comment = await octoClient.sendScheduledCommentNow(boardId, blockId)
+        if (comment) {
+            store.dispatch(updateComments([comment as CommentBlock]))
+        }
+        return comment
+    }
+
+    /**
+     * Update a scheduled comment's content or scheduled time
+     */
+    async updateScheduledComment(
+        boardId: string,
+        blockId: string,
+        title?: string,
+        scheduledAt?: number,
+    ): Promise<Block | undefined> {
+        const comment = await octoClient.updateScheduledComment(boardId, blockId, title, scheduledAt)
+        if (comment) {
+            store.dispatch(updateComments([comment as CommentBlock]))
+        }
+        return comment
+    }
+
+    /**
+     * Fetch scheduled comments for a card
+     */
+    async fetchScheduledCommentsForCard(boardId: string, cardId: string): Promise<Block[]> {
+        const comments = await octoClient.getScheduledCommentsForCard(boardId, cardId)
+        if (comments.length > 0) {
+            store.dispatch(updateComments(comments as CommentBlock[]))
+        }
+        return comments
+    }
+
+    /**
+     * Fetch all scheduled comments for the current user
+     */
+    async fetchMyScheduledComments(): Promise<Block[]> {
+        return octoClient.getMyScheduledComments()
+    }
 }
 
 const mutator = new Mutator()

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -1297,6 +1297,124 @@ class OctoClient {
 
         console.log('[API] ✅ Save successful')
     }
+
+    // ========================================
+    // Scheduled Comments API
+    // ========================================
+
+    /**
+     * Get all scheduled comments for the current user
+     */
+    async getMyScheduledComments(): Promise<Block[]> {
+        const path = '/api/v2/me/scheduled-comments'
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'GET',
+            headers: this.headers(),
+        }))
+        if (response.status !== 200) {
+            return []
+        }
+        return (await this.getJson(response, [])) as Block[]
+    }
+
+    /**
+     * Create a scheduled comment
+     */
+    async createScheduledComment(
+        boardId: string,
+        cardId: string,
+        title: string,
+        scheduledAt: number,
+    ): Promise<Block | undefined> {
+        const path = `/api/v2/boards/${boardId}/scheduled-comments`
+        const body = JSON.stringify({
+            cardId,
+            title,
+            scheduledAt,
+        })
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'POST',
+            headers: this.headers(),
+            body,
+        }))
+        if (response.status !== 200) {
+            return undefined
+        }
+        return (await this.getJson(response, undefined)) as Block | undefined
+    }
+
+    /**
+     * Get scheduled comments for a specific card
+     */
+    async getScheduledCommentsForCard(boardId: string, cardId: string): Promise<Block[]> {
+        const path = `/api/v2/boards/${boardId}/cards/${cardId}/scheduled-comments`
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'GET',
+            headers: this.headers(),
+        }))
+        if (response.status !== 200) {
+            return []
+        }
+        return (await this.getJson(response, [])) as Block[]
+    }
+
+    /**
+     * Update a scheduled comment
+     */
+    async updateScheduledComment(
+        boardId: string,
+        blockId: string,
+        title?: string,
+        scheduledAt?: number,
+    ): Promise<Block | undefined> {
+        const path = `/api/v2/boards/${boardId}/scheduled-comments/${blockId}`
+        const body: Record<string, any> = {}
+        if (title !== undefined) {
+            body.title = title
+        }
+        if (scheduledAt !== undefined) {
+            body.scheduledAt = scheduledAt
+        }
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'PATCH',
+            headers: this.headers(),
+            body: JSON.stringify(body),
+        }))
+        if (response.status !== 200) {
+            return undefined
+        }
+        return (await this.getJson(response, undefined)) as Block | undefined
+    }
+
+    /**
+     * Cancel a scheduled comment
+     */
+    async cancelScheduledComment(boardId: string, blockId: string): Promise<Block | undefined> {
+        const path = `/api/v2/boards/${boardId}/scheduled-comments/${blockId}/cancel`
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'POST',
+            headers: this.headers(),
+        }))
+        if (response.status !== 200) {
+            return undefined
+        }
+        return (await this.getJson(response, undefined)) as Block | undefined
+    }
+
+    /**
+     * Immediately send a scheduled comment
+     */
+    async sendScheduledCommentNow(boardId: string, blockId: string): Promise<Block | undefined> {
+        const path = `/api/v2/boards/${boardId}/scheduled-comments/${blockId}/send-now`
+        const response = await fetch(this.getBaseURL() + path, Client4.getOptions({
+            method: 'POST',
+            headers: this.headers(),
+        }))
+        if (response.status !== 200) {
+            return undefined
+        }
+        return (await this.getJson(response, undefined)) as Block | undefined
+    }
 }
 
 const octoClient = new OctoClient()


### PR DESCRIPTION
## 개요

댓글을 특정 시간에 자동으로 발송하는 예약 전송 기능을 구현했습니다.

## 주요 변경사항

### Backend (Go)
- `server/api/scheduled_comments.go` - 예약 댓글 API 엔드포인트
- `server/app/scheduled_comments.go` - 비즈니스 로직 (생성, 취소, 즉시 발송, 채널 알림)
- `server/services/store/sqlstore/scheduled_comments.go` - DB 쿼리

### Frontend (React/TypeScript)
- `webapp/src/components/cardDetail/commentsList.tsx` - 예약 버튼 및 예약 댓글 표시
- `webapp/src/components/cardDetail/comment.tsx` - 예약 댓글 시각적 구분 (반투명, 파란 테두리)
- `webapp/src/components/cardDetail/scheduledCommentPicker.tsx` - 날짜/시간 선택 UI
- `webapp/src/components/cardDetail/scheduledComment.tsx` - 예약 댓글 컴포넌트

## 기능 상세

### 댓글 예약
- 댓글 입력 후 🕐 버튼 클릭 → 날짜/시간 선택 → Schedule 클릭
- 최소 1분 후 ~ 최대 30일 이내 예약 가능
- 사용자당 최대 10개 예약 제한

### 예약 댓글 표시
- 예약 대기 중인 댓글은 **작성자 본인에게만** 표시
- 반투명 처리 + 파란색 왼쪽 테두리로 시각적 구분
- 🕐 아이콘과 함께 예약 시간 표시

### 채널 알림
- 예약 시간 도달 시 보드와 연결된 채널에 자동 알림 전송
- 알림 형식: `📝 **사용자명** commented on [카드 제목](링크): > 댓글 내용`

## API 엔드포인트

| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST | `/api/v2/boards/{boardID}/scheduled-comments` | 예약 댓글 생성 |
| GET | `/api/v2/boards/{boardID}/cards/{cardID}/scheduled-comments` | 카드의 예약 댓글 조회 |
| GET | `/api/v2/me/scheduled-comments` | 내 예약 댓글 전체 조회 |
| PATCH | `/api/v2/boards/{boardID}/scheduled-comments/{blockID}` | 예약 댓글 수정 |
| POST | `/api/v2/boards/{boardID}/scheduled-comments/{blockID}/cancel` | 예약 취소 |
| POST | `/api/v2/boards/{boardID}/scheduled-comments/{blockID}/send-now` | 즉시 발송 |

## 테스트 방법

1. 카드 상세 페이지에서 댓글 입력
2. 🕐 버튼 클릭 후 예약 시간 설정
3. Schedule 버튼 클릭
4. 예약된 댓글이 반투명으로 표시되는지 확인
5. 예약 시간 도달 시 채널에 알림 확인