### PR TITLE
Refactor: 숨긴 팀일 경우 보드에서 안보이게 처리, 정렬 시 선택 팀 우선으로

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -1078,29 +1078,35 @@ func (s *SQLStore) searchBoardsForUser(db sq.BaseRunner, term string, searchFiel
 		Select(boardFields("b.")...).
 		From(s.tablePrefix + "boards as b").
 		Join(s.tablePrefix + "board_members as bm on b.id=bm.board_id").
+		Join("Teams as t on t.Id=b.team_id").
 		Where(sq.Eq{
 			"b.is_template": false,
 			"bm.user_id":    userID,
+			"t.DeleteAt":    0,
 		})
 
 	teamMembersQ := builder.
 		Select(boardFields("b.")...).
 		From(s.tablePrefix + "boards as b").
 		Join("TeamMembers as tm on tm.teamid=b.team_id").
+		Join("Teams as t on t.Id=b.team_id").
 		Where(sq.Eq{
 			"b.is_template": false,
 			"tm.userID":     userID,
 			"tm.deleteAt":   0,
 			"b.type":        model.BoardTypeOpen,
+			"t.DeleteAt":    0,
 		})
 
 	channelMembersQ := builder.
 		Select(boardFields("b.")...).
 		From(s.tablePrefix + "boards as b").
 		Join("ChannelMembers as cm on cm.channelId=b.channel_id").
+		Join("Teams as t on t.Id=b.team_id").
 		Where(sq.Eq{
 			"b.is_template": false,
 			"cm.userId":     userID,
+			"t.DeleteAt":    0,
 		})
 
 	if term != "" {

--- a/server/services/store/sqlstore/team.go
+++ b/server/services/store/sqlstore/team.go
@@ -202,7 +202,8 @@ func (s *SQLStore) getTeamsForUser(db sq.BaseRunner, userID string) ([]*model.Te
 		From("Teams as t").
 		Join("TeamMembers as tm on t.Id=tm.TeamId").
 		Where(sq.Eq{"tm.UserId": userID}).
-		Where(sq.Eq{"tm.DeleteAt": 0})
+		Where(sq.Eq{"tm.DeleteAt": 0}).
+		Where(sq.Eq{"t.DeleteAt": 0})
 
 	rows, err := query.Query()
 	if err != nil {

--- a/webapp/src/components/boardsSwitcherDialog/boardSwitcherDialog.tsx
+++ b/webapp/src/components/boardsSwitcherDialog/boardSwitcherDialog.tsx
@@ -67,12 +67,26 @@ const BoardSwitcherDialog = (props: Props): JSX.Element => {
         }
 
         const items = await octoClient.searchAll(query)
+        const currentTeamItems: typeof items = []
+        const otherTeamItems: typeof items = []
+        for (const item of items) {
+            if (item.teamId === team.id) {
+                currentTeamItems.push(item)
+            } else {
+                otherTeamItems.push(item)
+            }
+        }
+        const sortedItems = currentTeamItems.concat(otherTeamItems)
         const untitledBoardTitle = intl.formatMessage({id: 'ViewTitle.untitled-board', defaultMessage: 'Untitled board'})
-        refs.current = items.map((_, i) => refs.current[i] ?? createRef())
+        refs.current = sortedItems.map((_, i) => refs.current[i] ?? createRef())
         setRefs(refs)
-        return items.map((item, i) => {
+        return sortedItems.flatMap((item, i) => {
             const resultTitle = item.title || untitledBoardTitle
-            const teamTitle = teamsById[item.teamId].title
+            const teamInfo = teamsById[item.teamId]
+            if (!teamInfo) {
+                return []
+            }
+            const teamTitle = teamInfo.title
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             setIDs((prevIDs: any) => ({
                 ...prevIDs,


### PR DESCRIPTION

- Updated SQL queries in `searchBoardsForUser`, `getTeamsForUser`, and related methods to include checks for `DeleteAt` field in the `Teams` table, ensuring that only active teams are considered in board searches and team retrievals.
- Improved data integrity by preventing deleted teams from appearing in user-specific board and team lists.