### PR TITLE
feat: 하위 카드 리스트/보드 뷰 표시 개선 (#54)

### DIFF
--- a/server/model/card.go
+++ b/server/model/card.go
@@ -360,6 +360,9 @@ func CardPatch2BlockPatch(cardPatch *CardPatch) (*BlockPatch, error) {
 	if cardPatch.Icon != nil {
 		updatedFields["icon"] = cardPatch.Icon
 	}
+	if cardPatch.ParentCardID != nil {
+		updatedFields["parentCardId"] = *cardPatch.ParentCardID
+	}
 	if cardPatch.Depth != nil {
 		updatedFields["depth"] = *cardPatch.Depth
 	}

--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -22,6 +22,7 @@ import CopyLinkTourStep from '../onboardingTour/copyLink/copy_link'
 import CardActionsMenu from '../cardActionsMenu/cardActionsMenu'
 import CardActionsMenuIcon from '../cardActionsMenu/cardActionsMenuIcon'
 import {getValidEmojiData} from '../../utils/emojiUtils'
+import KanbanSubCardChips from './kanbanSubCardChips'
 
 export const OnboardingCardClassName = 'onboardingCard'
 
@@ -159,6 +160,10 @@ const KanbanCard = (props: Props) => {
                     </Tooltip>
                 ))}
                 {props.visibleBadges && <CardBadges card={card}/>}
+                <KanbanSubCardChips
+                    parentCardId={card.id}
+                    showCard={props.showCard}
+                />
                 {showOnboarding && !params.cardId && <OpenCardTourStep/>}
                 {showOnboarding && !params.cardId && <CopyLinkTourStep/>}
             </div>

--- a/webapp/src/components/kanban/kanbanSubCardChips.scss
+++ b/webapp/src/components/kanban/kanbanSubCardChips.scss
@@ -1,0 +1,39 @@
+.KanbanSubCardChips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: 100%;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+
+    &__chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        max-width: 100%;
+        padding: 2px 8px;
+        border-radius: 4px;
+        background-color: rgba(var(--center-channel-color-rgb), 0.06);
+        cursor: pointer;
+        font-size: 12px;
+        line-height: 20px;
+        transition: background-color 100ms ease-out;
+
+        &:hover {
+            background-color: rgba(var(--center-channel-color-rgb), 0.12);
+        }
+    }
+
+    &__chip-icon {
+        flex-shrink: 0;
+        font-size: 12px;
+    }
+
+    &__chip-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: rgba(var(--center-channel-color-rgb), 0.72);
+    }
+}

--- a/webapp/src/components/kanban/kanbanSubCardChips.tsx
+++ b/webapp/src/components/kanban/kanbanSubCardChips.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback} from 'react'
+
+import {Card} from '../../blocks/card'
+import useSubCardInfo from '../../hooks/useSubCardInfo'
+
+import './kanbanSubCardChips.scss'
+
+type Props = {
+    parentCardId: string
+    showCard: (cardId?: string) => void
+}
+
+const KanbanSubCardChips = (props: Props): React.JSX.Element | null => {
+    const {parentCardId, showCard} = props
+    const {subCards, hasSubCards} = useSubCardInfo(parentCardId)
+
+    const handleChipClick = useCallback((e: React.MouseEvent, cardId: string) => {
+        e.stopPropagation()
+        showCard(cardId)
+    }, [showCard])
+
+    const handleChipKeyDown = useCallback((e: React.KeyboardEvent, cardId: string) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            showCard(cardId)
+        }
+    }, [showCard])
+
+    if (!hasSubCards) {
+        return null
+    }
+
+    return (
+        <div className='KanbanSubCardChips'>
+            {subCards.map((card: Card) => (
+                <div
+                    key={card.id}
+                    className='KanbanSubCardChips__chip'
+                    onClick={(e) => handleChipClick(e, card.id)}
+                    onKeyDown={(e) => handleChipKeyDown(e, card.id)}
+                    role='button'
+                    tabIndex={0}
+                >
+                    <span className='KanbanSubCardChips__chip-icon'>
+                        {card.fields.icon || '\uD83D\uDCC4'}
+                    </span>
+                    <span className='KanbanSubCardChips__chip-title'>
+                        {card.title || 'Untitled'}
+                    </span>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export default React.memo(KanbanSubCardChips)

--- a/webapp/src/components/table/tableRow.scss
+++ b/webapp/src/components/table/tableRow.scss
@@ -60,6 +60,42 @@
         width: 24px;
     }
 
+    .expand-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        padding: 0;
+        margin-right: 2px;
+        color: rgba(var(--center-channel-color-rgb), 0.56);
+        border-radius: 2px;
+
+        i {
+            font-size: 16px;
+            transition: transform 150ms ease;
+        }
+
+        &:hover {
+            background-color: rgba(var(--center-channel-color-rgb), 0.08);
+            color: rgba(var(--center-channel-color-rgb), 0.72);
+        }
+
+        &--expanded i {
+            transform: rotate(90deg);
+        }
+    }
+
+    .sub-card-indent {
+        display: inline-block;
+        flex-shrink: 0;
+        width: 22px;
+    }
+
     .URLProperty:hover .Button_Copy {
         display: none;
     }

--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -44,6 +44,10 @@ type Props = {
     addCard: (groupByOptionId?: string) => Promise<void>
     onClick?: (e: React.MouseEvent<HTMLDivElement>, card: Card) => void
     onDrop: (srcCard: Card, dstCard: Card) => void
+    hasSubCards?: boolean
+    isExpanded?: boolean
+    onToggleExpand?: (e: React.MouseEvent) => void
+    isSubCard?: boolean
 }
 
 const TableRow = (props: Props) => {
@@ -167,6 +171,17 @@ const TableRow = (props: Props) => {
                 style={{width: columnResize.width(Constants.titleColumnId)}}
                 ref={(ref) => columnResize.updateRef(card.id, Constants.titleColumnId, ref)}
             >
+                {props.hasSubCards && (
+                    <button
+                        className={`expand-toggle ${props.isExpanded ? 'expand-toggle--expanded' : ''}`}
+                        onClick={props.onToggleExpand}
+                    >
+                        <i className='CompassIcon icon-chevron-right'/>
+                    </button>
+                )}
+                {props.isSubCard && !props.hasSubCards && (
+                    <span className='sub-card-indent'/>
+                )}
                 <div className='octo-icontitle'>
                     <div className='octo-icon'>{card.fields.icon}</div>
                     <Editable

--- a/webapp/src/components/table/tableRowExpandable.tsx
+++ b/webapp/src/components/table/tableRowExpandable.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState, useCallback, useEffect} from 'react'
+
+import {Card} from '../../blocks/card'
+import {Board} from '../../blocks/board'
+import {BoardView} from '../../blocks/boardView'
+import useSubCardInfo from '../../hooks/useSubCardInfo'
+
+import TableRow from './tableRow'
+import TableSubCardRows from './tableSubCardRows'
+
+type Props = {
+    board: Board
+    activeView: BoardView
+    card: Card
+    selectedCardIds: string[]
+    readonly: boolean
+    cardIdToFocusOnRender: string
+    isLastCard: boolean
+    showCard: (cardId?: string) => void
+    addCard: (groupByOptionId?: string) => Promise<void>
+    onCardClicked: (e: React.MouseEvent, card: Card) => void
+    onDrop: (srcCard: Card, dstCard: Card) => void
+}
+
+const TableRowExpandable = (props: Props): React.JSX.Element => {
+    const {board, activeView, card} = props
+    const {subCards, hasSubCards} = useSubCardInfo(card.id)
+    const [expanded, setExpanded] = useState(false)
+
+    useEffect(() => {
+        if (!hasSubCards) {
+            setExpanded(false)
+        }
+    }, [hasSubCards])
+
+    const handleToggle = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation()
+        setExpanded((prev) => !prev)
+    }, [])
+
+    return (
+        <>
+            <TableRow
+                board={board}
+                columnWidths={activeView.fields.columnWidths}
+                isManualSort={activeView.fields.sortOptions.length === 0}
+                groupById={activeView.fields.groupById}
+                visiblePropertyIds={activeView.fields.visiblePropertyIds}
+                collapsedOptionIds={activeView.fields.collapsedOptionIds}
+                card={card}
+                addCard={props.addCard}
+                isSelected={props.selectedCardIds.includes(card.id)}
+                focusOnMount={props.cardIdToFocusOnRender === card.id}
+                isLastCard={props.isLastCard}
+                onClick={(e) => props.onCardClicked(e, card)}
+                showCard={props.showCard}
+                readonly={props.readonly}
+                onDrop={props.onDrop}
+                hasSubCards={hasSubCards}
+                isExpanded={expanded}
+                onToggleExpand={handleToggle}
+            />
+            {hasSubCards && expanded && (
+                <TableSubCardRows
+                    board={board}
+                    activeView={activeView}
+                    subCards={subCards}
+                    selectedCardIds={props.selectedCardIds}
+                    readonly={props.readonly}
+                    showCard={props.showCard}
+                    addCard={props.addCard}
+                    onCardClicked={props.onCardClicked}
+                    onDrop={props.onDrop}
+                />
+            )}
+        </>
+    )
+}
+
+export default React.memo(TableRowExpandable)

--- a/webapp/src/components/table/tableRows.tsx
+++ b/webapp/src/components/table/tableRows.tsx
@@ -9,7 +9,7 @@ import {BoardView} from '../../blocks/boardView'
 
 import './table.scss'
 
-import TableRow from './tableRow'
+import TableRowExpandable from './tableRowExpandable'
 
 type Props = {
     board: Board
@@ -27,7 +27,7 @@ type Props = {
 const TableRows = (props: Props): React.JSX.Element => {
     const {board, cards, activeView} = props
 
-    const onClickRow = useCallback((e: React.MouseEvent<HTMLDivElement>, card: Card) => {
+    const onClickRow = useCallback((e: React.MouseEvent, card: Card) => {
         props.onCardClicked(e, card)
     }, [props.onCardClicked])
 
@@ -35,22 +35,18 @@ const TableRows = (props: Props): React.JSX.Element => {
         <>
             {cards.map((card, idx) => {
                 return (
-                    <TableRow
+                    <TableRowExpandable
                         key={card.id + card.updateAt}
                         board={board}
-                        columnWidths={activeView.fields.columnWidths}
-                        isManualSort={activeView.fields.sortOptions.length === 0}
-                        groupById={activeView.fields.groupById}
-                        visiblePropertyIds={activeView.fields.visiblePropertyIds}
-                        collapsedOptionIds={activeView.fields.collapsedOptionIds}
+                        activeView={activeView}
                         card={card}
-                        addCard={props.addCard}
-                        isSelected={props.selectedCardIds.includes(card.id)}
-                        focusOnMount={props.cardIdToFocusOnRender === card.id}
-                        isLastCard={idx === (cards.length - 1)}
-                        onClick={onClickRow}
-                        showCard={props.showCard}
+                        selectedCardIds={props.selectedCardIds}
                         readonly={props.readonly}
+                        cardIdToFocusOnRender={props.cardIdToFocusOnRender}
+                        isLastCard={idx === (cards.length - 1)}
+                        showCard={props.showCard}
+                        addCard={props.addCard}
+                        onCardClicked={onClickRow}
                         onDrop={props.onDrop}
                     />)
             })}

--- a/webapp/src/components/table/tableSubCardRows.tsx
+++ b/webapp/src/components/table/tableSubCardRows.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+
+import {Card} from '../../blocks/card'
+import {Board} from '../../blocks/board'
+import {BoardView} from '../../blocks/boardView'
+
+import TableRow from './tableRow'
+
+type Props = {
+    board: Board
+    activeView: BoardView
+    subCards: Card[]
+    selectedCardIds: string[]
+    readonly: boolean
+    showCard: (cardId?: string) => void
+    addCard: (groupByOptionId?: string) => Promise<void>
+    onCardClicked: (e: React.MouseEvent, card: Card) => void
+    onDrop: (srcCard: Card, dstCard: Card) => void
+}
+
+const TableSubCardRows = (props: Props): React.JSX.Element => {
+    const {board, activeView, subCards} = props
+
+    return (
+        <>
+            {subCards.map((card, idx) => (
+                <TableRow
+                    key={card.id}
+                    board={board}
+                    columnWidths={activeView.fields.columnWidths}
+                    isManualSort={activeView.fields.sortOptions.length === 0}
+                    groupById={activeView.fields.groupById}
+                    visiblePropertyIds={activeView.fields.visiblePropertyIds}
+                    collapsedOptionIds={activeView.fields.collapsedOptionIds}
+                    card={card}
+                    addCard={props.addCard}
+                    isSelected={props.selectedCardIds.includes(card.id)}
+                    focusOnMount={false}
+                    isLastCard={idx === subCards.length - 1}
+                    onClick={(e) => props.onCardClicked(e, card)}
+                    showCard={props.showCard}
+                    readonly={props.readonly}
+                    onDrop={props.onDrop}
+                    isSubCard={true}
+                />
+            ))}
+        </>
+    )
+}
+
+export default React.memo(TableSubCardRows)

--- a/webapp/src/hooks/useSubCardInfo.ts
+++ b/webapp/src/hooks/useSubCardInfo.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useMemo} from 'react'
+
+import {Card} from '../blocks/card'
+import {useAppSelector} from '../store/hooks'
+import {getCurrentBoardSubCardsByParent} from '../store/cards'
+
+type SubCardInfo = {
+    count: number
+    subCards: Card[]
+    hasSubCards: boolean
+}
+
+const useSubCardInfo = (parentCardId: string): SubCardInfo => {
+    const subCardsByParent = useAppSelector(getCurrentBoardSubCardsByParent)
+
+    return useMemo(() => {
+        const subCards = subCardsByParent[parentCardId] || []
+        return {
+            count: subCards.length,
+            subCards,
+            hasSubCards: subCards.length > 0,
+        }
+    }, [subCardsByParent, parentCardId])
+}
+
+export default useSubCardInfo

--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -125,11 +125,36 @@ const cardsSlice = createSlice({
         },
         setSubCards: (state, action: PayloadAction<{parentCardId: string, subCards: Card[]}>) => {
             state.subCardsByParent[action.payload.parentCardId] = action.payload.subCards
+
+            // 메인 카드 스토어의 parentCardId도 동기화
+            for (const subCard of action.payload.subCards) {
+                if (state.cards[subCard.id]) {
+                    state.cards[subCard.id] = {
+                        ...state.cards[subCard.id],
+                        fields: {
+                            ...state.cards[subCard.id].fields,
+                            parentCardId: action.payload.parentCardId,
+                        },
+                    }
+                }
+            }
         },
         addSubCard: (state, action: PayloadAction<{parentCardId: string, subCard: Card}>) => {
             const existing = state.subCardsByParent[action.payload.parentCardId] || []
             state.subCardsByParent[action.payload.parentCardId] = [...existing, action.payload.subCard]
             state.subCardCountByParent[action.payload.parentCardId] = (state.subCardCountByParent[action.payload.parentCardId] || 0) + 1
+
+            // 메인 카드 스토어의 parentCardId도 동기화
+            const subCard = action.payload.subCard
+            if (state.cards[subCard.id]) {
+                state.cards[subCard.id] = {
+                    ...state.cards[subCard.id],
+                    fields: {
+                        ...state.cards[subCard.id].fields,
+                        parentCardId: action.payload.parentCardId,
+                    },
+                }
+            }
         },
         setSubCardCount: (state, action: PayloadAction<{parentCardId: string, count: number}>) => {
             state.subCardCountByParent[action.payload.parentCardId] = action.payload.count
@@ -144,6 +169,17 @@ const cardsSlice = createSlice({
             const currentCount = state.subCardCountByParent[action.payload.parentCardId] || 0
             if (currentCount > 0) {
                 state.subCardCountByParent[action.payload.parentCardId] = currentCount - 1
+            }
+
+            // 메인 카드 스토어의 parentCardId 제거
+            if (state.cards[action.payload.cardId]) {
+                state.cards[action.payload.cardId] = {
+                    ...state.cards[action.payload.cardId],
+                    fields: {
+                        ...state.cards[action.payload.cardId].fields,
+                        parentCardId: '',
+                    },
+                }
             }
         },
     },
@@ -215,6 +251,40 @@ export const getCurrentBoardCards = createSelector(
     getCards,
     (boardId, cards) => {
         return Object.values(cards).filter((c) => c.boardId === boardId) as Card[]
+    },
+)
+
+export const getCurrentBoardParentCards = createSelector(
+    getCurrentBoardCards,
+    (cards) => {
+        return cards.filter((c) => !c.fields.parentCardId)
+    },
+)
+
+export const getCurrentBoardSubCardsByParent = createSelector(
+    getCurrentBoardCards,
+    (cards) => {
+        const map: {[parentCardId: string]: Card[]} = {}
+        for (const card of cards) {
+            if (card.fields.parentCardId) {
+                if (!map[card.fields.parentCardId]) {
+                    map[card.fields.parentCardId] = []
+                }
+                map[card.fields.parentCardId].push(card)
+            }
+        }
+        return map
+    },
+)
+
+export const getCurrentBoardSubCardCountByParent = createSelector(
+    getCurrentBoardSubCardsByParent,
+    (subCardsByParent) => {
+        const map: {[parentCardId: string]: number} = {}
+        for (const [parentId, subCards] of Object.entries(subCardsByParent)) {
+            map[parentId] = subCards.length
+        }
+        return map
     },
 )
 
@@ -462,7 +532,7 @@ function searchFilterCards(cards: Card[], board: Board, searchTextRaw: string): 
 }
 
 export const getCurrentViewCardsSortedFilteredAndGroupedWithoutLimit = createSelector(
-    getCurrentBoardCards,
+    getCurrentBoardParentCards,
     getLastCommentByCard,
     getCurrentBoard,
     getCurrentView,


### PR DESCRIPTION
## Summary
- 칸반/테이블 뷰에서 하위 카드(sub-card)가 독립 카드로 표시되는 문제 해결
- 상위 카드 내에 하위 카드를 인라인으로 표시하여 계층 구조를 시각적으로 구분
- 기존 카드를 하위 카드로 연결 시 `parentCardId`가 블록 fields에 저장되지 않던 서버 버그 수정
<img width="2720" height="1256" alt="image" src="https://github.com/user-attachments/assets/f5a482d0-dd96-40a5-9aa0-7f55bbe31814" />
<img width="584" height="546" alt="image" src="https://github.com/user-attachments/assets/36bd6849-184b-4ce3-ab0e-ba9e4c43d9ca" />

## Changes

### Server (Go)
- **`server/model/card.go`**: `CardPatch2BlockPatch`에서 `parentCardId`를 `updatedFields`에 포함하도록 수정. 기존에는 `blockPatch.ParentID`만 설정하고 `fields.parentCardId`는 누락되어, 연결된 하위 카드가 프론트엔드에서 인식되지 않았음

### Frontend (React/TypeScript)

#### Redux 셀렉터 (`store/cards.ts`)
- `getCurrentBoardParentCards`: `parentCardId`가 있는 카드를 제외하여 상위 카드만 반환
- `getCurrentBoardSubCardsByParent`: 부모별 하위 카드 맵 생성
- `getCurrentViewCardsSortedFilteredAndGroupedWithoutLimit`: 상위 카드만 사용하도록 변경 → 모든 뷰에서 하위 카드가 독립 카드로 표시되지 않음
- `addSubCard`/`removeSubCard`/`setSubCards` 리듀서에서 메인 카드 스토어 동기화 추가

#### 칸반 뷰
- **`kanbanSubCardChips.tsx`** (신규): 부모 카드 내부에 하위 카드를 소형 칩(아이콘+제목)으로 표시, 클릭 시 카드 상세 열기
- **`kanbanCard.tsx`**: CardBadges 아래에 KanbanSubCardChips 렌더링

#### 테이블 뷰
- **`tableRowExpandable.tsx`** (신규): `TableRow`를 래핑하여 ▶/▼ 확장 토글 제공
- **`tableSubCardRows.tsx`** (신규): 타이틀 셀만 들여쓴 하위 카드 행 렌더링 (컬럼 정렬 유지)
- **`tableRow.tsx`**: `hasSubCards`/`isExpanded`/`onToggleExpand`/`isSubCard` props 추가, 타이틀 셀 내부에 토글/들여쓰기 렌더링
- **`tableRows.tsx`**: `TableRow` → `TableRowExpandable`로 교체

#### 커스텀 훅
- **`useSubCardInfo.ts`** (신규): 부모 카드의 하위 카드 정보 제공 (추가 API 호출 없음)

## Test plan
- [ ] 칸반 뷰: 하위 카드가 있는 상위 카드에 칩 표시되는지, 칩 클릭 시 카드 상세 열리는지 확인
- [ ] 테이블 뷰: 확장 토글로 하위 카드 행이 타이틀만 들여쓰기되어 표시되는지, 컬럼 정렬이 유지되는지 확인
- [ ] 하위 카드가 더 이상 독립 카드로 칸반 컬럼/테이블 행에 나타나지 않는지 확인
- [ ] 기존 카드를 하위 카드로 연결 후 칸반/테이블 뷰에 즉시 반영되는지 확인
- [ ] 하위 카드 해제(unlink) 후 독립 카드로 다시 표시되는지 확인
- [ ] 카드 상세 모달의 SubCards 섹션 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)