### PR TITLE
feat: Markdown 및 Lexical 에디터에 멘션 매핑 기능 추가

### DIFF
--- a/webapp/src/components/cardDetail/commentsList.tsx
+++ b/webapp/src/components/cardDetail/commentsList.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState} from 'react'
+import React, {useCallback, useRef, useState} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 
 import {CommentBlock, createCommentBlock, getScheduledAt, isPendingScheduledComment} from '../../blocks/commentBlock'
@@ -12,6 +12,7 @@ import Button from '../../widgets/buttons/button'
 import CompassIcon from '../../widgets/icons/compassIcon'
 
 import {MarkdownEditor} from '../markdownEditor'
+import type {MentionMapping} from '../lexicalEditor/LexicalEditorInput'
 
 import {IUser} from '../../user'
 import {getMe} from '../../store/users'
@@ -24,6 +25,38 @@ import Comment from './comment'
 import ScheduledCommentPicker from './scheduledCommentPicker'
 
 import './commentsList.scss'
+
+/**
+ * 메시지 내의 @displayname을 @username으로 변환합니다.
+ * mentionMappings에 저장된 매핑 정보를 사용합니다.
+ */
+function convertDisplayNamesToUsernames(message: string, mentionMappings?: Record<string, MentionMapping>): string {
+    if (!mentionMappings || Object.keys(mentionMappings).length === 0) {
+        return message
+    }
+
+    // 메시지 끝에 있는 멘션을 처리하기 위해 임시 공백 추가
+    let convertedMessage = message + ' '
+
+    // displayname이 긴 것부터 먼저 변환 (부분 매칭 방지)
+    const sortedMappings = Object.entries(mentionMappings).sort(
+        ([a], [b]) => b.length - a.length,
+    )
+
+    for (const [displayName, mapping] of sortedMappings) {
+        // @displayname 패턴을 찾아서 @username으로 변환
+        // - (^|\\s): @ 앞에 문자열 시작 또는 공백이 있어야 함 (이메일 주소 등에서 잘못 변환되는 것 방지)
+        // - (?=\\s|...): @ 뒤에 공백이나 구두점이 있어야 함
+        const escapedDisplayName = displayName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        const pattern = new RegExp(`(^|\\s)@${escapedDisplayName}(?=\\s|[.,!?;:'"\\)\\]}>])`, 'gm')
+
+        // 콜백 함수를 사용하여 특수 대체 패턴 문자($&, $' 등)가 username에 있어도 안전하게 처리
+        convertedMessage = convertedMessage.replace(pattern, (_match, prefix) => `${prefix}@${mapping.username}`)
+    }
+
+    // 임시로 추가한 공백 제거
+    return convertedMessage.slice(0, -1)
+}
 
 type Props = {
     comments: readonly CommentBlock[]
@@ -41,18 +74,31 @@ const CommentsList = (props: Props) => {
 
     const {comments, boardId, cardId} = props
 
+    // 멘션 매핑: displayname -> username 변환을 위한 ref
+    // ref를 사용하여 연속 멘션 선택 시 최신 상태를 유지
+    const mentionMappingsRef = useRef<Record<string, MentionMapping>>({})
+
+    const handleMentionMappingsChange = useCallback((mappings: Record<string, MentionMapping>) => {
+        mentionMappingsRef.current = mappings
+    }, [])
+
     const onSendClicked = () => {
         const commentText = newComment
         if (commentText) {
             Utils.log(`Send comment: ${commentText}`)
             Utils.assertValue(cardId)
 
+            // @displayname을 @username으로 변환
+            const convertedText = convertDisplayNamesToUsernames(commentText, mentionMappingsRef.current)
+
             const comment = createCommentBlock()
             comment.parentId = cardId
             comment.boardId = boardId
-            comment.title = commentText
+            comment.title = convertedText
             mutator.insertBlock(boardId, comment, 'add comment')
             setNewComment('')
+            // 멘션 매핑 초기화
+            mentionMappingsRef.current = {}
         }
     }
 
@@ -62,9 +108,14 @@ const CommentsList = (props: Props) => {
             Utils.log(`Schedule comment: ${commentText}`)
             Utils.assertValue(cardId)
 
+            // @displayname을 @username으로 변환
+            const convertedText = convertDisplayNamesToUsernames(commentText, mentionMappingsRef.current)
+
             try {
-                await mutator.createScheduledComment(boardId, cardId, commentText, scheduledAt)
+                await mutator.createScheduledComment(boardId, cardId, convertedText, scheduledAt)
                 setNewComment('')
+                // 멘션 매핑 초기화
+                mentionMappingsRef.current = {}
             } catch (err) {
                 Utils.log(`Failed to schedule comment: ${err}`)
             }
@@ -87,6 +138,7 @@ const CommentsList = (props: Props) => {
                         setNewComment(value)
                     }
                 }}
+                onMentionMappingsChange={handleMentionMappingsChange}
             />
 
             {newComment && (

--- a/webapp/src/components/lexicalEditor/LexicalEditorInput.tsx
+++ b/webapp/src/components/lexicalEditor/LexicalEditorInput.tsx
@@ -44,8 +44,16 @@ import './lexicalEditor.scss'
 
 const BotBadge = (window as any).Components?.BotBadge
 
+// 멘션 매핑 타입: displayname -> username 매핑
+export type MentionMapping = {
+    userId: string
+    username: string
+    displayName: string
+}
+
 type Props = {
     onChange?: (text: string) => void
+    onMentionMappingsChange?: (mappings: Record<string, MentionMapping>) => void
     onFocus?: () => void
     onBlur?: (text: string) => void
     onEditorCancel?: () => void
@@ -144,7 +152,7 @@ const EmojiMenuItem = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuItemP
 EmojiMenuItem.displayName = 'EmojiMenuItem'
 
 const LexicalEditorInput = (props: Props): React.ReactElement => {
-    const {onChange, onFocus, onBlur, initialText, id, saveOnEnter, onEditorCancel} = props
+    const {onChange, onMentionMappingsChange, onFocus, onBlur, initialText, id, saveOnEnter, onEditorCancel} = props
     const boardUsers = useAppSelector<IUser[]>(getBoardUsersList)
     const board = useAppSelector(getCurrentBoard)
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
@@ -154,6 +162,8 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
     const editorRef = useRef<LexicalEditor | null>(null)
 
     const userMapRef = useRef<Map<string, IUser>>(new Map())
+    // mentionMappings: displayName을 키로 사용하여 username 저장
+    const mentionMappingsRef = useRef<Record<string, MentionMapping>>({})
 
     const loadSuggestions = useCallback(async (query?: string | null): Promise<BeautifulMentionsItem[]> => {
         const term = query || ''
@@ -186,15 +196,21 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
             userMapRef.current.set(user.id, user)
         })
 
-        return users.map((user: IUser): BeautifulMentionsItem => ({
-            value: user.username,
-            id: user.id,
-            avatar: Utils.getProfilePicture(user.id),
-            is_bot: user.is_bot,
-            is_guest: user.is_guest,
-            displayName: Utils.getUserDisplayName(user, clientConfig.teammateNameDisplay),
-            isBoardMember: boardMemberIds.has(user.id),
-        }))
+        return users.map((user: IUser): BeautifulMentionsItem => {
+            const displayName = Utils.getUserDisplayName(user, clientConfig.teammateNameDisplay)
+            return {
+                // value는 화면에 표시되는 값: displayName으로 표시
+                value: displayName,
+                id: user.id,
+                avatar: Utils.getProfilePicture(user.id),
+                is_bot: user.is_bot,
+                is_guest: user.is_guest,
+                displayName,
+                // username을 별도로 저장하여 전송 시 변환에 사용
+                username: user.username,
+                isBoardMember: boardMemberIds.has(user.id),
+            }
+        })
     }, [me, allowManageBoardRoles, board, boardUsers, clientConfig.teammateNameDisplay])
 
     const debouncedSearch = useMemo(
@@ -222,6 +238,19 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
         (menuItem: BeautifulMentionsMenuItem) => {
             const userId = menuItem.data?.id as string | undefined
             const isBoardMember = menuItem.data?.isBoardMember as boolean | undefined
+            const displayName = menuItem.data?.displayName as string | undefined
+            const username = menuItem.data?.username as string | undefined
+
+            // mentionMappings에 displayName -> username 매핑 저장
+            if (userId && displayName && username) {
+                mentionMappingsRef.current[displayName] = {
+                    userId,
+                    username,
+                    displayName,
+                }
+                // 부모 컴포넌트에 매핑 정보 전달
+                onMentionMappingsChange?.({...mentionMappingsRef.current})
+            }
 
             if (userId && isBoardMember === false) {
                 const user = userMapRef.current.get(userId)
@@ -230,7 +259,7 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
                 }
             }
         },
-        [],
+        [onMentionMappingsChange],
     )
 
     const handleEmojiSearch = useCallback(

--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -6,6 +6,8 @@ import React, {useState, Suspense} from 'react'
 import {Utils} from '../utils'
 import './markdownEditor.scss'
 
+import type {MentionMapping} from './lexicalEditor/LexicalEditorInput'
+
 const LexicalEditorInput = React.lazy(() => import('./lexicalEditor/LexicalEditorInput'))
 
 type Props = {
@@ -16,6 +18,7 @@ type Props = {
     readonly?: boolean
 
     onChange?: (text: string) => void
+    onMentionMappingsChange?: (mappings: Record<string, MentionMapping>) => void
     onFocus?: () => void
     onBlur?: (text: string) => void
     onKeyDown?: (e: React.KeyboardEvent) => void
@@ -25,7 +28,7 @@ type Props = {
 }
 
 const MarkdownEditor = (props: Props): React.JSX.Element => {
-    const {placeholderText, onFocus, onEditorCancel, onBlur, onChange, text, id, saveOnEnter} = props
+    const {placeholderText, onFocus, onEditorCancel, onBlur, onChange, onMentionMappingsChange, text, id, saveOnEnter} = props
     const [isEditing, setIsEditing] = useState(Boolean(props.autofocus))
     const html: string = Utils.htmlFromMarkdown(text || placeholderText || '')
 
@@ -59,6 +62,7 @@ const MarkdownEditor = (props: Props): React.JSX.Element => {
             <LexicalEditorInput
                 id={id}
                 onChange={onChange}
+                onMentionMappingsChange={onMentionMappingsChange}
                 onFocus={onFocus}
                 onEditorCancel={onEditorCancel}
                 onBlur={editorOnBlur}


### PR DESCRIPTION
MarkdownEditor와 LexicalEditorInput 컴포넌트에 사용자 멘션 매핑 처리를 위한 onMentionMappingsChange prop을 추가했습니다. CommentsList에 표시 이름을 사용자명으로 변환하는 convertDisplayNamesToUsernames 함수를 구현했습니다. 댓글을 보내거나 예약할 때 멘션이 올바른 형식으로 변환되도록 하여 사용자 경험을 개선했습니다.