### PR TITLE
feat: 알림 처리 개선을 위한 배치 멘션 전송 구현

### DIFF
--- a/.cursor/rules/features/notifications/_index.mdc
+++ b/.cursor/rules/features/notifications/_index.mdc
@@ -177,4 +177,4 @@ a.logger.Debug("Sending notification",
 
 | 질문 | 파일 |
 |------|------|
-| (새 질문이 생기면 여기에 추가) | |
+| 여러 사용자 멘션 시 알림을 한 번에 처리하는 방법 | `q-batch-mention-notification.mdc` |

--- a/.cursor/rules/features/notifications/q-batch-mention-notification.mdc
+++ b/.cursor/rules/features/notifications/q-batch-mention-notification.mdc
@@ -1,0 +1,153 @@
+---
+description: 댓글에서 여러 사용자를 멘션할 때 배치 알림 처리 방식
+globs: ["server/services/notify/**"]
+---
+
+# 배치 멘션 알림 (Batch Mention Notification)
+
+## 배경
+
+댓글에서 여러 사용자를 동시에 멘션할 때 (`@user1 @user2 @user3`), 기존에는 각 사용자마다 개별 알림 메시지가 생성되어 채널에 3개의 알림이 게시되는 문제가 있었습니다.
+
+### 기존 문제
+
+```
+댓글: "@홍길동 @김철수 @이영희 확인 부탁드립니다"
+
+채널에 게시된 알림:
+1. "@작성자님이 @홍길동님을 카드 [카드명] 댓글에서 언급했습니다"
+2. "@작성자님이 @김철수님을 카드 [카드명] 댓글에서 언급했습니다"  
+3. "@작성자님이 @이영희님을 카드 [카드명] 댓글에서 언급했습니다"
+```
+
+## 해결 방안
+
+**채널 연결 보드**와 **채널 미연결 보드(DM 모드)**를 구분하여 처리합니다.
+
+### 채널 연결 보드 (배치 모드)
+
+여러 멘션을 모아서 **한 개의 메시지**로 채널에 전송합니다.
+
+```
+채널에 게시된 알림 (1개):
+"@작성자님이 @홍길동, @김철수, @이영희님을 카드 [카드명] 댓글에서 언급했습니다"
+```
+
+### 채널 미연결 보드 (DM 모드)
+
+각 사용자에게 **개별 DM**으로 전송합니다. (기존 동작 유지)
+
+```
+홍길동 DM: "@작성자님이 @홍길동님을 카드 [카드명] 댓글에서 언급했습니다"
+김철수 DM: "@작성자님이 @김철수님을 카드 [카드명] 댓글에서 언급했습니다"
+이영희 DM: "@작성자님이 @이영희님을 카드 [카드명] 댓글에서 언급했습니다"
+```
+
+## 구현 상세
+
+### 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `server/services/notify/notifymentions/delivery.go` | `BatchMentionDeliver` 인터페이스 정의 |
+| `server/services/notify/notifymentions/mentions_backend.go` | 배치/개별 처리 분기 로직 |
+| `server/services/notify/plugindelivery/mention_deliver.go` | `BatchMentionDeliver` 구현 |
+| `server/services/notify/plugindelivery/message.go` | 다중 멘션 메시지 포맷 |
+
+### 핵심 로직
+
+```go
+// mentions_backend.go
+func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
+    // ... 멘션 추출 ...
+
+    // 채널 연결 보드인 경우 배치 처리
+    if evt.Board.ChannelID != "" {
+        return b.processBatchMentions(newMentions, evt, listeners)
+    }
+
+    // DM 모드: 기존대로 개별 처리
+    return b.processIndividualMentions(newMentions, evt, listeners)
+}
+```
+
+### 배치 처리 흐름
+
+```
+1. BlockChanged() 호출
+   ↓
+2. 새로운 멘션 추출 (기존 멘션 제외)
+   ↓
+3. evt.Board.ChannelID 확인
+   ├─ 있음 → processBatchMentions()
+   │         ├─ 유효한 사용자 수집 (validateAndProcessMention)
+   │         ├─ 권한 검사 & 자동 멤버 추가
+   │         └─ BatchMentionDeliver() → 채널에 1개 메시지
+   │
+   └─ 없음 → processIndividualMentions()
+             └─ 각 사용자에게 개별 DM
+```
+
+### 인터페이스
+
+```go
+// delivery.go
+type MentionDelivery interface {
+    MentionDeliver(mentionedUser *mm_model.User, extract string, evt notify.BlockChangeEvent) (string, error)
+    UserByUsername(mentionUsername string) (*mm_model.User, error)
+    // BatchMentionDeliver sends a single notification for multiple mentioned users.
+    BatchMentionDeliver(mentionedUsers []*mm_model.User, extract string, evt notify.BlockChangeEvent) ([]string, error)
+}
+```
+
+### 메시지 포맷
+
+```go
+// message.go
+const (
+    // 단일 멘션 (DM용)
+    defCommentTemplate = "@%s님이 @%s님을 카드 [%s](%s) 댓글에서 언급했습니다 (보드: [%s](%s))\n> %s"
+    
+    // 다중 멘션 (채널용)
+    defBatchCommentTemplate = "@%s님이 %s님을 카드 [%s](%s) 댓글에서 언급했습니다 (보드: [%s](%s))\n> %s"
+)
+
+// formatUserList: ["user1", "user2"] → "@user1, @user2"
+```
+
+## 동작 예시
+
+### 입력
+
+```
+보드: 채널 연결됨 (channel_id: "ch123")
+댓글: "@홍길동 @김철수 @이영희 내일까지 확인 부탁드립니다"
+```
+
+### 출력
+
+**채널 (ch123)**:
+```
+@작성자님이 @홍길동, @김철수, @이영희님을 카드 [프로젝트 일정](link) 댓글에서 언급했습니다 (보드: [개발 보드](link))
+> @홍길동 @김철수 @이영희 내일까지 확인 부탁드립니다
+```
+
+## 권한 처리
+
+배치 모드에서도 각 멘션된 사용자에 대해 개별적으로 권한 검사를 수행합니다:
+
+1. **공개 보드**: 팀 멤버만 멘션 가능, 멘션 시 자동으로 보드 멤버로 추가
+2. **비공개 보드**: 보드 멤버만 멘션 가능
+3. **Viewer 권한**: 멘션 불가 (댓글 작성 권한 없음)
+
+권한이 없는 사용자는 배치에서 제외되고, 유효한 사용자들만 알림에 포함됩니다.
+
+## 테스트 시나리오
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 채널 연결 보드에서 3명 멘션 | 채널에 1개 메시지 |
+| 채널 미연결 보드에서 3명 멘션 | 각 사용자에게 DM 3개 |
+| 3명 중 1명이 권한 없음 | 채널에 2명만 포함된 1개 메시지 |
+| 이미 멘션된 사용자 다시 멘션 | 알림 안 감 (중복 방지) |
+| 존재하지 않는 @username | 무시됨 |

--- a/.cursor/rules/features/properties/q-text-property-save-bug.mdc
+++ b/.cursor/rules/features/properties/q-text-property-save-bug.mdc
@@ -1,0 +1,173 @@
+---
+description: 텍스트 프로퍼티 저장 시 가끔 저장되지 않는 버그 수정
+globs: ["webapp/src/properties/baseTextEditor.tsx", "webapp/src/properties/url/url.tsx"]
+---
+
+# 텍스트 프로퍼티 저장 버그 수정
+
+## 문제 상황
+
+텍스트 기반 프로퍼티(text, number, email, phone, url 등)를 편집할 때 가끔씩 값이 저장되지 않는 문제가 발생했습니다.
+
+### 증상
+
+1. 프로퍼티 값을 수정하고 다른 카드로 이동하면 저장되지 않음
+2. 같은 카드라도 서버에서 업데이트가 오면 편집 중인 값이 사라짐
+3. 드물게 다른 카드에 값이 저장되는 데이터 손상 발생
+
+## 원인 분석
+
+### 버그 1: 빈 useEffect 의존성 배열
+
+```typescript
+// 문제 코드
+useEffect(() => {
+    return () => {
+        saveTextPropertyRef.current && saveTextPropertyRef.current()
+    }
+}, [])  // ← 빈 배열! 카드 변경 시 cleanup이 호출되지 않음
+```
+
+- 컴포넌트가 완전히 언마운트될 때만 cleanup 호출
+- **같은 컴포넌트가 다른 카드로 재사용**되면 cleanup이 호출되지 않아 저장 실패
+
+### 버그 2: 렌더링 중 ref 업데이트로 인한 stale closure
+
+```typescript
+// 문제 코드
+const saveTextPropertyRef = useRef<() => void>(saveTextProperty)
+if (props.readOnly) {
+    saveTextPropertyRef.current = () => null
+} else {
+    saveTextPropertyRef.current = saveTextProperty  // 렌더링 중에 업데이트!
+}
+```
+
+React 실행 순서:
+1. 새 props로 렌더링 → `saveTextPropertyRef.current`에 **새 콜백** 저장
+2. 이전 useEffect cleanup 실행 → **새 콜백**이 호출됨 (이전 값을 새 카드에 저장!)
+
+### 버그 3: card 객체 참조로 인한 stale 데이터
+
+```typescript
+// 문제 코드
+pendingSaveRef.current = {
+    card: props.card,  // ← 참조만 저장!
+    ...
+}
+```
+
+- Redux store가 업데이트되면 `props.card` 참조가 가리키는 데이터가 변경됨
+- cleanup 시 stale card 데이터로 저장 시도
+
+### 버그 4: 서버 값 변경 미감지
+
+```typescript
+// 문제 코드
+useEffect(() => {
+    setValue(props.card.fields.properties[propertyId] || '')
+}, [props.card.id, props.propertyTemplate?.id])  // ← 서버 값 변경 미감지
+```
+
+- 같은 ID의 카드라도 서버에서 업데이트되면 값이 변경됨
+- 서버 값이 변경되어도 로컬 state는 이전 값 유지
+
+## 해결 방법
+
+### 수정된 코드 구조
+
+```typescript
+const BaseTextEditor = (props: PropertyProps) => {
+    const [value, setValue] = useState(...)
+
+    // 1. 저장 대기 데이터를 ref로 관리 (card 깊은 복사)
+    const pendingSaveRef = useRef<{
+        boardId: string
+        card: typeof props.card  // 깊은 복사본
+        propertyId: string
+        value: string
+        originalValue: string | string[]
+        readOnly: boolean
+    } | null>(null)
+
+    // 2. 값 변경 시 저장 대기 데이터 업데이트
+    useEffect(() => {
+        const propertyId = props.propertyTemplate?.id || ''
+        const originalValue = props.card.fields.properties[propertyId] ?? ''
+        pendingSaveRef.current = {
+            boardId: props.board.id,
+            // card 객체 깊은 복사 (Redux 업데이트로 인한 stale 참조 방지)
+            card: {
+                ...props.card,
+                fields: {
+                    ...props.card.fields,
+                    properties: {...props.card.fields.properties},
+                },
+            },
+            propertyId,
+            value: value as string,
+            originalValue,
+            readOnly: props.readOnly,
+        }
+    }, [props.board.id, props.card, props.propertyTemplate?.id, value, props.readOnly])
+
+    // 3. 카드/프로퍼티 변경 시 cleanup에서 이전 값 저장
+    useEffect(() => {
+        return () => {
+            const pending = pendingSaveRef.current
+            if (pending && !pending.readOnly && pending.value !== pending.originalValue) {
+                mutator.changePropertyValue(pending.boardId, pending.card, pending.propertyId, pending.value)
+            }
+        }
+    }, [props.card.id, props.propertyTemplate?.id])
+
+    // 4. 서버 값 변경 감지하여 로컬 state 동기화
+    const serverValue = props.card.fields.properties[props.propertyTemplate?.id || ''] || ''
+    useEffect(() => {
+        setValue(serverValue)
+    }, [props.card.id, props.propertyTemplate?.id, serverValue])
+
+    // ...
+}
+```
+
+### 핵심 수정 포인트
+
+| 문제 | 해결 |
+|------|------|
+| 빈 의존성 배열 | `[props.card.id, props.propertyTemplate?.id]` 추가 |
+| 렌더링 중 ref 업데이트 | useEffect 내에서만 업데이트 |
+| card 참조 문제 | 깊은 복사하여 스냅샷 저장 |
+| 서버 값 미감지 | `serverValue`를 의존성에 추가 |
+
+## 영향 범위
+
+### 수정된 파일
+
+| 파일 | 설명 |
+|------|------|
+| `webapp/src/properties/baseTextEditor.tsx` | text, number, email, phone 프로퍼티 |
+| `webapp/src/properties/url/url.tsx` | URL 프로퍼티 |
+
+### 영향받지 않는 프로퍼티
+
+| 프로퍼티 | 이유 |
+|---------|------|
+| select, multiselect | 선택 시 즉시 저장 (로컬 state 없음) |
+| checkbox | 클릭 시 즉시 저장 |
+| date | 다이얼로그 닫을 때 저장 |
+| person, multiperson | 선택 시 즉시 저장 |
+
+## 주의사항
+
+### 사용자 경험
+
+- 서버 값이 변경되면 편집 중인 로컬 값이 서버 값으로 덮어씌워짐
+- 이는 의도된 동작으로, 다른 사용자의 변경사항을 반영함
+- 충돌 방지를 위해 onBlur에서 즉시 저장하는 것이 권장됨
+
+### 테스트 시나리오
+
+1. 텍스트 프로퍼티 편집 후 다른 카드로 이동 → 저장 확인
+2. 편집 중 WebSocket으로 서버 업데이트 수신 → 서버 값 반영 확인
+3. 테이블 뷰에서 여러 카드의 같은 프로퍼티 빠르게 편집 → 각 카드에 올바른 값 저장 확인

--- a/server/services/notify/notifymentions/delivery.go
+++ b/server/services/notify/notifymentions/delivery.go
@@ -15,4 +15,8 @@ import (
 type MentionDelivery interface {
 	MentionDeliver(mentionedUser *mm_model.User, extract string, evt notify.BlockChangeEvent) (string, error)
 	UserByUsername(mentionUsername string) (*mm_model.User, error)
+	// BatchMentionDeliver sends a single notification for multiple mentioned users.
+	// Used when board is linked to a channel to avoid duplicate messages.
+	// Returns the list of user IDs that were successfully notified.
+	BatchMentionDeliver(mentionedUsers []*mm_model.User, extract string, evt notify.BlockChangeEvent) ([]string, error)
 }

--- a/server/services/notify/notifymentions/mentions_backend.go
+++ b/server/services/notify/notifymentions/mentions_backend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-boards/server/services/permissions"
 	"github.com/wiggin77/merror"
 
+	mm_model "github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
@@ -109,19 +110,93 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 	}
 
 	oldMentions := extractMentions(evt.BlockOld)
-	merr := merror.New()
+
+	// 새로운 멘션만 필터링 (기존에 없던 것들)
+	newMentions := make(map[string]struct{})
+	for username := range mentions {
+		if _, exists := oldMentions[username]; !exists {
+			newMentions[username] = struct{}{}
+		}
+	}
+
+	if len(newMentions) == 0 {
+		return nil
+	}
 
 	b.mux.RLock()
 	listeners := make([]MentionListener, len(b.listeners))
 	copy(listeners, b.listeners)
 	b.mux.RUnlock()
 
-	for username := range mentions {
-		if _, exists := oldMentions[username]; exists {
-			// the mention already existed; no need to notify again
+	// 채널 연결 보드인 경우 배치 처리
+	if evt.Board.ChannelID != "" {
+		return b.processBatchMentions(newMentions, evt, listeners)
+	}
+
+	// DM 모드: 기존대로 개별 처리
+	return b.processIndividualMentions(newMentions, evt, listeners)
+}
+
+// processBatchMentions handles mentions for boards linked to a channel.
+// All valid mentions are collected and sent as a single message to the channel.
+func (b *Backend) processBatchMentions(newMentions map[string]struct{}, evt notify.BlockChangeEvent, listeners []MentionListener) error {
+	merr := merror.New()
+	validUsers := make([]*mm_model.User, 0, len(newMentions))
+	validUserIDs := make([]string, 0, len(newMentions))
+
+	// 유효한 멘션 사용자들 수집
+	for username := range newMentions {
+		user, err := b.validateAndProcessMention(username, evt)
+		if err != nil {
+			if errors.Is(err, ErrMentionPermission) {
+				b.logger.Debug("Cannot deliver notification", mlog.String("user", username), mlog.Err(err))
+			} else {
+				merr.Append(fmt.Errorf("cannot validate mention for @%s: %w", username, err))
+			}
 			continue
 		}
+		if user != nil {
+			validUsers = append(validUsers, user)
+			validUserIDs = append(validUserIDs, user.Id)
+		}
+	}
 
+	if len(validUsers) == 0 {
+		return merr.ErrorOrNil()
+	}
+
+	// 배치 전송 (한 번에 모든 멘션된 사용자들에게)
+	// extractText를 사용하여 개별 DM과 동일하게 ~100자로 제한
+	// 배치 알림에서는 첫 번째 사용자 이름을 기준으로 추출 (모든 사용자에게 동일한 내용)
+	firstUsername := validUsers[0].Username
+	extract := extractText(evt.BlockChanged.Title, firstUsername, newLimits())
+	userIDs, err := b.delivery.BatchMentionDeliver(validUsers, extract, evt)
+	if err != nil {
+		merr.Append(fmt.Errorf("cannot deliver batch notification: %w", err))
+		return merr.ErrorOrNil()
+	}
+
+	b.logger.Debug("Batch mention notification delivered",
+		mlog.Int("user_count", len(userIDs)),
+		mlog.Int("listener_count", len(listeners)),
+	)
+
+	// 리스너들에게 알림
+	for _, userID := range userIDs {
+		for _, listener := range listeners {
+			safeCallListener(listener, userID, evt, b.logger)
+		}
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// processIndividualMentions handles mentions for boards not linked to a channel (DM mode).
+// Each mention is sent as a separate DM to the mentioned user.
+func (b *Backend) processIndividualMentions(newMentions map[string]struct{}, evt notify.BlockChangeEvent, listeners []MentionListener) error {
+	merr := merror.New()
+
+	for username := range newMentions {
 		extract := extractText(evt.BlockChanged.Title, username, newLimits())
 
 		userID, err := b.deliverMentionNotification(username, extract, evt)
@@ -131,10 +206,10 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 			} else {
 				merr.Append(fmt.Errorf("cannot deliver notification for @%s: %w", username, err))
 			}
+			continue
 		}
 
 		if userID == "" {
-			// was a `@` followed by something other than a username.
 			continue
 		}
 
@@ -147,6 +222,7 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 			safeCallListener(listener, userID, evt, b.logger)
 		}
 	}
+
 	return merr.ErrorOrNil()
 }
 
@@ -158,6 +234,68 @@ func safeCallListener(listener MentionListener, userID string, evt notify.BlockC
 		}
 	}()
 	listener.OnMention(userID, evt)
+}
+
+// validateAndProcessMention validates if a mention is allowed and processes auto-membership.
+// Returns the mentioned user if valid, nil if the username doesn't exist.
+func (b *Backend) validateAndProcessMention(username string, evt notify.BlockChangeEvent) (*mm_model.User, error) {
+	mentionedUser, err := b.delivery.UserByUsername(username)
+	if err != nil {
+		if model.IsErrNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot lookup mentioned user: %w", err)
+	}
+
+	if evt.ModifiedBy == nil {
+		return nil, fmt.Errorf("invalid user cannot mention: %w", ErrMentionPermission)
+	}
+
+	if evt.Board.Type == model.BoardTypeOpen {
+		switch {
+		case evt.ModifiedBy.SchemeAdmin, evt.ModifiedBy.SchemeEditor, evt.ModifiedBy.SchemeCommenter:
+			if !b.permissions.HasPermissionToTeam(mentionedUser.Id, evt.TeamID, model.PermissionViewTeam) {
+				return nil, fmt.Errorf("%s cannot mention non-team member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+			member, err := b.appAPI.GetMemberForBoard(evt.Board.ID, mentionedUser.Id)
+			if member == nil || model.IsErrNotFound(err) {
+				newBoardMember := &model.BoardMember{
+					UserID:  mentionedUser.Id,
+					BoardID: evt.Board.ID,
+					SchemeViewer: evt.Board.MinimumRole == model.BoardRoleViewer ||
+						evt.Board.MinimumRole == model.BoardRoleCommenter ||
+						evt.Board.MinimumRole == model.BoardRoleEditor,
+					SchemeCommenter: evt.Board.MinimumRole == model.BoardRoleCommenter ||
+						evt.Board.MinimumRole == model.BoardRoleEditor,
+					SchemeEditor: evt.Board.MinimumRole == model.BoardRoleEditor,
+				}
+				if _, err = b.appAPI.AddMemberToBoard(newBoardMember); err != nil {
+					return nil, fmt.Errorf("cannot add mentioned user %s to board %s: %w", mentionedUser.Id, evt.Board.ID, err)
+				}
+				b.logger.Debug("auto-added mentioned user to board",
+					mlog.String("user_id", mentionedUser.Id),
+					mlog.String("board_id", evt.Board.ID),
+				)
+			}
+		case evt.ModifiedBy.SchemeViewer:
+			return nil, fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+		default:
+			if !b.permissions.HasPermissionToBoard(mentionedUser.Id, evt.Board.ID, model.PermissionViewBoard) {
+				return nil, fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+		}
+	} else {
+		switch {
+		case evt.ModifiedBy.SchemeViewer:
+			return nil, fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+		default:
+			if !b.permissions.HasPermissionToBoard(mentionedUser.Id, evt.Board.ID, model.PermissionViewBoard) {
+				return nil, fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+		}
+	}
+
+	return mentionedUser, nil
 }
 
 func (b *Backend) deliverMentionNotification(username string, extract string, evt notify.BlockChangeEvent) (string, error) {

--- a/server/services/notify/plugindelivery/mention_deliver.go
+++ b/server/services/notify/plugindelivery/mention_deliver.go
@@ -12,25 +12,18 @@ import (
 	mm_model "github.com/mattermost/mattermost/server/public/model"
 )
 
-// MentionDeliver notifies a user they have been mentioned in a blockv ia the plugin API.
+// MentionDeliver notifies a user they have been mentioned in a block via the plugin API.
+// Used for DM notifications (when board is not linked to a channel).
 func (pd *PluginDelivery) MentionDeliver(mentionedUser *mm_model.User, extract string, evt notify.BlockChangeEvent) (string, error) {
 	author, err := pd.api.GetUserByID(evt.ModifiedBy.UserID)
 	if err != nil {
 		return "", fmt.Errorf("cannot find user: %w", err)
 	}
 
-	// 보드에 연결된 채널이 있으면 그 채널로 메시지 전송, 없으면 DM으로 전송
-	var channelID string
-	if evt.Board.ChannelID != "" {
-		// 보드와 연결된 채널로 메시지 전송
-		channelID = evt.Board.ChannelID
-	} else {
-		// DM 채널로 메시지 전송 (기존 방식)
-		channel, err := pd.getDirectChannel(evt.TeamID, mentionedUser.Id, pd.botID)
-		if err != nil {
-			return "", fmt.Errorf("cannot get direct channel: %w", err)
-		}
-		channelID = channel.Id
+	// DM 채널로 메시지 전송
+	channel, err := pd.getDirectChannel(evt.TeamID, mentionedUser.Id, pd.botID)
+	if err != nil {
+		return "", fmt.Errorf("cannot get direct channel: %w", err)
 	}
 
 	link := utils.MakeCardLink(pd.serverRoot, evt.Board.TeamID, evt.Board.ID, evt.Card.ID)
@@ -38,7 +31,7 @@ func (pd *PluginDelivery) MentionDeliver(mentionedUser *mm_model.User, extract s
 
 	post := &mm_model.Post{
 		UserId:    pd.botID,
-		ChannelId: channelID,
+		ChannelId: channel.Id,
 		Message:   formatMessage(author.Username, mentionedUser.Username, extract, evt.Card.Title, link, evt.BlockChanged, boardLink, evt.Board.Title),
 	}
 
@@ -47,4 +40,45 @@ func (pd *PluginDelivery) MentionDeliver(mentionedUser *mm_model.User, extract s
 	}
 
 	return mentionedUser.Id, nil
+}
+
+// BatchMentionDeliver sends a single notification to a channel for multiple mentioned users.
+// This is used when the board is linked to a channel to avoid duplicate messages.
+func (pd *PluginDelivery) BatchMentionDeliver(mentionedUsers []*mm_model.User, extract string, evt notify.BlockChangeEvent) ([]string, error) {
+	if len(mentionedUsers) == 0 {
+		return nil, nil
+	}
+
+	// 채널 연결이 없으면 배치 전송 불가
+	if evt.Board.ChannelID == "" {
+		return nil, fmt.Errorf("batch mention delivery requires board to be linked to a channel")
+	}
+
+	author, err := pd.api.GetUserByID(evt.ModifiedBy.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find user: %w", err)
+	}
+
+	link := utils.MakeCardLink(pd.serverRoot, evt.Board.TeamID, evt.Board.ID, evt.Card.ID)
+	boardLink := utils.MakeBoardLink(pd.serverRoot, evt.Board.TeamID, evt.Board.ID)
+
+	// 멘션된 사용자들의 username 목록 추출
+	usernames := make([]string, len(mentionedUsers))
+	userIDs := make([]string, len(mentionedUsers))
+	for i, user := range mentionedUsers {
+		usernames[i] = user.Username
+		userIDs[i] = user.Id
+	}
+
+	post := &mm_model.Post{
+		UserId:    pd.botID,
+		ChannelId: evt.Board.ChannelID,
+		Message:   formatBatchMessage(author.Username, usernames, extract, evt.Card.Title, link, evt.BlockChanged, boardLink, evt.Board.Title),
+	}
+
+	if _, err := pd.api.CreatePost(post); err != nil {
+		return nil, err
+	}
+
+	return userIDs, nil
 }

--- a/server/services/notify/plugindelivery/message.go
+++ b/server/services/notify/plugindelivery/message.go
@@ -5,6 +5,7 @@ package plugindelivery
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/model"
 )
@@ -13,6 +14,10 @@ const (
 	// TODO: localize these when i18n is available.
 	defCommentTemplate     = "@%s님이 @%s님을 카드 [%s](%s) 댓글에서 언급했습니다 (보드: [%s](%s))\n> %s"
 	defDescriptionTemplate = "@%s님이 @%s님을 카드 [%s](%s)에서 언급했습니다 (보드: [%s](%s))\n> %s"
+
+	// Templates for batch mentions (multiple users in one message)
+	defBatchCommentTemplate     = "@%s님이 %s님을 카드 [%s](%s) 댓글에서 언급했습니다 (보드: [%s](%s))\n> %s"
+	defBatchDescriptionTemplate = "@%s님이 %s님을 카드 [%s](%s)에서 언급했습니다 (보드: [%s](%s))\n> %s"
 )
 
 func formatMessage(author string, mentionedUser string, extract string, card string, link string, block *model.Block, boardLink string, board string) string {
@@ -21,4 +26,31 @@ func formatMessage(author string, mentionedUser string, extract string, card str
 		template = defCommentTemplate
 	}
 	return fmt.Sprintf(template, author, mentionedUser, card, link, board, boardLink, extract)
+}
+
+// formatBatchMessage formats a message for multiple mentioned users.
+func formatBatchMessage(author string, mentionedUsernames []string, extract string, card string, link string, block *model.Block, boardLink string, board string) string {
+	template := defBatchDescriptionTemplate
+	if block.Type == model.TypeComment {
+		template = defBatchCommentTemplate
+	}
+
+	// Format usernames as "@user1, @user2, @user3"
+	formattedUsers := formatUserList(mentionedUsernames)
+
+	return fmt.Sprintf(template, author, formattedUsers, card, link, board, boardLink, extract)
+}
+
+// formatUserList formats a list of usernames with @ prefix.
+// e.g., ["user1", "user2", "user3"] -> "@user1, @user2, @user3"
+func formatUserList(usernames []string) string {
+	if len(usernames) == 0 {
+		return ""
+	}
+
+	formatted := make([]string, len(usernames))
+	for i, username := range usernames {
+		formatted[i] = "@" + username
+	}
+	return strings.Join(formatted, ", ")
 }

--- a/webapp/src/properties/baseTextEditor.tsx
+++ b/webapp/src/properties/baseTextEditor.tsx
@@ -15,27 +15,63 @@ const BaseTextEditor = (props: PropertyProps & {validator: (value: string) => bo
     const [value, setValue] = useState(props.card.fields.properties[props.propertyTemplate.id || ''] || '')
     const onCancel = useCallback(() => setValue(props.propertyValue || ''), [props.propertyValue])
 
+    // 저장 대기 중인 데이터를 ref로 관리 (cleanup에서 안전하게 접근 가능)
+    // card 객체는 깊은 복사하여 stale 참조 문제 방지
+    const pendingSaveRef = useRef<{
+        boardId: string
+        card: typeof props.card
+        propertyId: string
+        value: string
+        originalValue: string | string[]
+        readOnly: boolean
+    } | null>(null)
+
+    // 값이 변경될 때마다 저장 대기 데이터 업데이트
+    useEffect(() => {
+        const propertyId = props.propertyTemplate?.id || ''
+        const originalValue = props.card.fields.properties[propertyId] ?? ''
+        pendingSaveRef.current = {
+            boardId: props.board.id,
+            // card 객체 깊은 복사 (Redux 업데이트로 인한 stale 참조 방지)
+            card: {
+                ...props.card,
+                fields: {
+                    ...props.card.fields,
+                    properties: {...props.card.fields.properties},
+                },
+            },
+            propertyId,
+            value: value as string,
+            originalValue,
+            readOnly: props.readOnly,
+        }
+    }, [props.board.id, props.card, props.propertyTemplate?.id, value, props.readOnly])
+
     const saveTextProperty = useCallback(() => {
         if (value !== (props.card.fields.properties[props.propertyTemplate?.id || ''] || '')) {
             mutator.changePropertyValue(props.board.id, props.card, props.propertyTemplate?.id || '', value)
         }
     }, [props.board.id, props.card, props.propertyTemplate?.id, value])
 
-    const saveTextPropertyRef = useRef<() => void>(saveTextProperty)
-    if (props.readOnly) {
-        saveTextPropertyRef.current = () => null
-    } else {
-        saveTextPropertyRef.current = saveTextProperty
-    }
-
     const intl = useIntl()
     const emptyDisplayValue = props.showEmptyPlaceholder ? intl.formatMessage({id: 'PropertyValueElement.empty', defaultMessage: 'Empty'}) : ''
 
+    // 카드나 프로퍼티가 변경될 때 cleanup에서 이전 값을 저장
     useEffect(() => {
         return () => {
-            saveTextPropertyRef.current && saveTextPropertyRef.current()
+            const pending = pendingSaveRef.current
+            if (pending && !pending.readOnly && pending.value !== pending.originalValue) {
+                mutator.changePropertyValue(pending.boardId, pending.card, pending.propertyId, pending.value)
+            }
         }
-    }, [])
+    }, [props.card.id, props.propertyTemplate?.id])
+
+    // 카드나 프로퍼티가 변경될 때, 또는 서버에서 값이 업데이트될 때 value를 초기화
+    // props.propertyValue는 서버에서 온 최신 값을 반영함
+    const serverValue = props.card.fields.properties[props.propertyTemplate?.id || ''] || ''
+    useEffect(() => {
+        setValue(serverValue)
+    }, [props.card.id, props.propertyTemplate?.id, serverValue])
 
     if (!props.readOnly) {
         return (

--- a/webapp/src/properties/url/url.tsx
+++ b/webapp/src/properties/url/url.tsx
@@ -32,23 +32,60 @@ const URLProperty = (props: PropertyProps): React.JSX.Element => {
 
     const emptyDisplayValue = props.showEmptyPlaceholder ? intl.formatMessage({id: 'PropertyValueElement.empty', defaultMessage: 'Empty'}) : ''
 
+    // 저장 대기 중인 데이터를 ref로 관리 (cleanup에서 안전하게 접근 가능)
+    // card 객체는 깊은 복사하여 stale 참조 문제 방지
+    const pendingSaveRef = useRef<{
+        boardId: string
+        card: typeof props.card
+        propertyId: string
+        value: string
+        originalValue: string | string[]
+        readOnly: boolean
+    } | null>(null)
+
+    // 값이 변경될 때마다 저장 대기 데이터 업데이트
+    useEffect(() => {
+        const propertyId = props.propertyTemplate?.id || ''
+        const originalValue = props.card.fields.properties[propertyId] ?? ''
+        pendingSaveRef.current = {
+            boardId: props.board.id,
+            // card 객체 깊은 복사 (Redux 업데이트로 인한 stale 참조 방지)
+            card: {
+                ...props.card,
+                fields: {
+                    ...props.card.fields,
+                    properties: {...props.card.fields.properties},
+                },
+            },
+            propertyId,
+            value: value as string,
+            originalValue,
+            readOnly: props.readOnly,
+        }
+    }, [props.board.id, props.card, props.propertyTemplate?.id, value, props.readOnly])
+
     const saveTextProperty = useCallback(() => {
         if (value !== (props.card.fields.properties[props.propertyTemplate?.id || ''] || '')) {
             mutator.changePropertyValue(props.board.id, props.card, props.propertyTemplate?.id || '', value)
         }
     }, [props.board.id, props.card, props.propertyTemplate?.id, value])
 
-    const saveTextPropertyRef = useRef<() => void>(saveTextProperty)
-    if (props.readOnly) {
-        saveTextPropertyRef.current = () => null
-    } else {
-        saveTextPropertyRef.current = saveTextProperty
-    }
+    // 카드나 프로퍼티가 변경될 때 cleanup에서 이전 값을 저장
     useEffect(() => {
         return () => {
-            saveTextPropertyRef.current && saveTextPropertyRef.current()
+            const pending = pendingSaveRef.current
+            if (pending && !pending.readOnly && pending.value !== pending.originalValue) {
+                mutator.changePropertyValue(pending.boardId, pending.card, pending.propertyId, pending.value)
+            }
         }
-    }, [])
+    }, [props.card.id, props.propertyTemplate?.id])
+
+    // 카드나 프로퍼티가 변경될 때, 또는 서버에서 값이 업데이트될 때 value를 초기화
+    // serverValue는 서버에서 온 최신 값을 반영함
+    const serverValue = props.card.fields.properties[props.propertyTemplate?.id || ''] || ''
+    useEffect(() => {
+        setValue(serverValue)
+    }, [props.card.id, props.propertyTemplate?.id, serverValue])
 
     useEffect(() => {
         if (isEditing) {


### PR DESCRIPTION
- MentionDelivery 인터페이스에 BatchMentionDeliver 메서드 추가: 여러 사용자에게 하나의 메시지로 알림을 전송하여 중복 알림 감소
- BlockChanged 메서드 개선: 보드가 채널에 연결된 경우 배치 멘션 처리로 사용자 알림 효율성 향상
- 전송 로직 업데이트: 보드 타입에 따라 배치/개별 멘션을 적절히 처리하여 올바른 알림 전달 보장
- 배치 알림을 위한 새로운 메시지 포맷 도입: 사용자 커뮤니케이션의 명확성과 일관성 유지