### PR TITLE
feat: 하위 카드 연결 해제 기능 개선 - parent_id 업데이트 추가

### DIFF
--- a/server/app/cards.go
+++ b/server/app/cards.go
@@ -377,6 +377,15 @@ func (a *App) UnlinkSubCard(cardID, userID string) (*model.Card, error) {
 		return nil, fmt.Errorf("failed to unlink card: %w", err)
 	}
 
+	// parent_id를 board_id로 설정 (최상위 카드는 parent_id = board_id여야 함)
+	blockPatch := &model.BlockPatch{
+		ParentID: &card.BoardID,
+	}
+	_, err = a.PatchBlockAndNotify(cardID, blockPatch, userID, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update parent_id to board_id: %w", err)
+	}
+
 	// Update depth of all sub-cards recursively
 	if oldDepth > 0 {
 		depthDelta := zeroDepth - oldDepth // negative value (e.g., 0 - 2 = -2)


### PR DESCRIPTION
- 하위 카드 연결 해제 시 parent_id를 board_id로 설정하는 로직 구현, 올바른 계층 구조 관리 보장
- parent_id 업데이트 과정에 에러 처리 추가로 안정성 및 사용자 피드백 개선