### PR TITLE
feat: ViewTabs 컴포넌트에서 활성 탭 스크롤 및 리네이밍 상태 초기화 기능 추가 (#77)

### DIFF
--- a/webapp/src/components/viewHeader/viewTabs.tsx
+++ b/webapp/src/components/viewHeader/viewTabs.tsx
@@ -149,6 +149,13 @@ const ViewTabs = (props: Props): React.JSX.Element => {
     }, [activeView.title])
 
     useEffect(() => {
+        setIsRenaming(false)
+        if (activeTabRef.current) {
+            activeTabRef.current.scrollIntoView({behavior: 'smooth', inline: 'center', block: 'nearest'})
+        }
+    }, [activeView.id])
+
+    useEffect(() => {
         if (isRenaming) {
             const frameId = requestAnimationFrame(() => {
                 editableRef.current?.focus(true)
@@ -249,6 +256,7 @@ const ViewTabs = (props: Props): React.JSX.Element => {
                     return (
                         <div
                             key={view.id}
+                            ref={activeTabRef}
                             className='ViewTab ViewTab--active ViewTab__editable'
                         >
                             <Editable


### PR DESCRIPTION
- activeView.id 변경 시 활성 탭이 부드럽게 스크롤되도록 설정
- 탭 이름 변경 시 리네이밍 상태를 초기화하는 로직 추가
- 활성 탭에 대한 ref를 추가하여 스크롤 동작을 구현