### PR TITLE
feat: LexicalEditor에 CompositionPlugin 추가 및 UI 개선

### DIFF
--- a/webapp/src/components/lexicalEditor/LexicalEditorInput.tsx
+++ b/webapp/src/components/lexicalEditor/LexicalEditorInput.tsx
@@ -39,6 +39,7 @@ import editorTheme, {mentionsTheme, emojiTheme} from './themes/editorTheme'
 import OnChangePlugin from './plugins/OnChangePlugin'
 import FocusPlugin from './plugins/FocusPlugin'
 import KeyboardPlugin from './plugins/KeyboardPlugin'
+import CompositionPlugin from './plugins/CompositionPlugin'
 
 import './lexicalEditor.scss'
 
@@ -63,13 +64,16 @@ type Props = {
     saveOnEnter?: boolean
 }
 
-const MentionsMenu = ({loading, ...props}: BeautifulMentionsMenuProps) => {
-    return (
-        <ul className='LexicalEditor__mentionsMenu' {...props}>
-            {props.children}
-        </ul>
-    )
-}
+const MentionsMenu = React.forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
+    ({loading, ...props}, ref) => {
+        return (
+            <ul ref={ref} className='LexicalEditor__mentionsMenu' {...props}>
+                {props.children}
+            </ul>
+        )
+    },
+)
+MentionsMenu.displayName = 'MentionsMenu'
 
 const MentionsMenuItem = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuItemProps>(
     ({selected, item, itemValue, ...restProps}, ref) => {
@@ -118,14 +122,6 @@ const MentionsMenuItem = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuIt
 )
 MentionsMenuItem.displayName = 'MentionsMenuItem'
 
-const EmojiMenu = ({loading, ...props}: BeautifulMentionsMenuProps) => {
-    return (
-        <ul className='LexicalEditor__emojiMenu' {...props}>
-            {props.children}
-        </ul>
-    )
-}
-
 const EmojiMenuItem = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuItemProps>(
     ({selected, item, itemValue, ...restProps}, ref) => {
         const data = typeof item === 'object' ? (item.data as Record<string, unknown>) || {} : {}
@@ -150,6 +146,17 @@ const EmojiMenuItem = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuItemP
     },
 )
 EmojiMenuItem.displayName = 'EmojiMenuItem'
+
+const TriggerMenuItemComponent = React.forwardRef<HTMLLIElement, BeautifulMentionsMenuItemProps>(
+    (itemProps, ref) => {
+        const trigger = (itemProps.item as {trigger?: string})?.trigger
+        if (trigger === ':') {
+            return <EmojiMenuItem ref={ref} {...itemProps}/>
+        }
+        return <MentionsMenuItem ref={ref} {...itemProps}/>
+    },
+)
+TriggerMenuItemComponent.displayName = 'TriggerMenuItemComponent'
 
 const LexicalEditorInput = (props: Props): React.ReactElement => {
     const {onChange, onMentionMappingsChange, onFocus, onBlur, initialText, id, saveOnEnter, onEditorCancel} = props
@@ -364,6 +371,7 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
                         onCancel={onEditorCancel}
                         editorRef={editorRef}
                     />
+                    <CompositionPlugin/>
                     <BeautifulMentionsPlugin
                         triggers={['@', ':']}
                         onSearch={(trigger, query) => {
@@ -373,19 +381,10 @@ const LexicalEditorInput = (props: Props): React.ReactElement => {
                             return handleMentionSearch(trigger, query)
                         }}
                         searchDelay={0}
+                        menuItemLimit={{'@': false, ':': 10}}
                         menuAnchorClassName='LexicalEditor__mentionsAnchor'
-                        menuComponent={(menuProps) => {
-                            if (menuProps.trigger === ':') {
-                                return <EmojiMenu {...menuProps}/>
-                            }
-                            return <MentionsMenu {...menuProps}/>
-                        }}
-                        menuItemComponent={(itemProps) => {
-                            if (itemProps.trigger === ':') {
-                                return <EmojiMenuItem {...itemProps}/>
-                            }
-                            return <MentionsMenuItem {...itemProps}/>
-                        }}
+                        menuComponent={MentionsMenu}
+                        menuItemComponent={TriggerMenuItemComponent}
                         onMenuItemSelect={(menuItem) => {
                             if (menuItem.trigger === ':') {
                                 return

--- a/webapp/src/components/lexicalEditor/lexicalEditor.scss
+++ b/webapp/src/components/lexicalEditor/lexicalEditor.scss
@@ -29,7 +29,7 @@
         border-radius: 4px;
         max-height: 300px;
         overflow-y: auto;
-        min-width: 200px;
+        min-width: 280px;
         padding: 4px 0;
         list-style: none;
         margin: 0;
@@ -40,9 +40,10 @@
         align-items: center;
         justify-content: space-between;
         height: 40px;
-        padding: 0 20px;
+        padding: 0 12px;
         cursor: pointer;
         list-style: none;
+        white-space: nowrap;
 
         &:hover {
             background: rgba(var(--center-channel-color-rgb), 0.08);
@@ -60,18 +61,24 @@
             display: flex;
             align-items: center;
             gap: 8px;
+            overflow: hidden;
+            flex: 1;
+            min-width: 0;
         }
 
         &__avatar {
             width: 24px;
             height: 24px;
             border-radius: 50%;
+            flex-shrink: 0;
         }
 
         &__name {
             display: flex;
             align-items: center;
             gap: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
 
             .Badge {
                 margin-left: 8px;
@@ -81,6 +88,8 @@
         &__hint {
             opacity: 0.56;
             font-size: 12px;
+            flex-shrink: 0;
+            margin-left: 8px;
         }
     }
 

--- a/webapp/src/components/lexicalEditor/plugins/CompositionPlugin.tsx
+++ b/webapp/src/components/lexicalEditor/plugins/CompositionPlugin.tsx
@@ -1,0 +1,149 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useEffect, useRef} from 'react'
+
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext'
+import {KEY_ENTER_COMMAND, LexicalEditor, SKIP_DOM_SELECTION_TAG} from 'lexical'
+
+/**
+ * Handles Korean IME composition interactions with Lexical editor:
+ *
+ * 1. Typeahead during composition:
+ *    LexicalTypeaheadMenuPlugin skips typeahead evaluation when
+ *    editor.isComposing() returns true. This prevents mention search
+ *    from updating while Korean characters are being composed.
+ *    We temporarily bypass isComposing() after each compositionupdate
+ *    and trigger a synchronous editor update so the typeahead can
+ *    re-evaluate with the composed text.
+ *
+ * 2. Enter key during composition:
+ *    When a user presses Enter during Korean IME composition, the browser
+ *    consumes the Enter key to finalize the composition. Lexical's
+ *    KEY_ENTER_COMMAND is never dispatched, so the typeahead menu cannot
+ *    select the highlighted item. We re-dispatch KEY_ENTER_COMMAND after
+ *    compositionend so the menu can process the selection.
+ */
+
+const HAS_DIRTY_NODES = 1
+
+export function CompositionPlugin(): null {
+    const [editor] = useLexicalComposerContext()
+    const enterDuringCompositionRef = useRef(false)
+    const bypassComposingRef = useRef(false)
+
+    // Override editor.isComposing() so that LexicalTypeaheadMenuPlugin's
+    // update listener can run during Korean IME composition when we
+    // explicitly set the bypass flag.
+    useEffect(() => {
+        const originalIsComposing = editor.isComposing
+
+        editor.isComposing = function(this: LexicalEditor) {
+            if (bypassComposingRef.current) {
+                return false
+            }
+            return originalIsComposing.call(this)
+        }
+
+        return () => {
+            editor.isComposing = originalIsComposing
+        }
+    }, [editor])
+
+    // After each compositionupdate, force the typeahead to re-evaluate
+    // by triggering a synchronous editor update with the bypass flag.
+    //
+    // Key details:
+    //   - _dirtyType = HAS_DIRTY_NODES forces Lexical to call
+    //     commitPendingUpdates (and thus update listeners), even though
+    //     no actual nodes are dirty. The reconciler sees empty dirty sets
+    //     and skips all DOM mutations.
+    //   - discrete: true makes the commit synchronous so the bypass flag
+    //     is still active when update listeners execute.
+    //   - SKIP_DOM_SELECTION_TAG prevents DOM selection changes that would
+    //     break the active IME composition.
+    useEffect(() => {
+        const rootElement = editor.getRootElement()
+        if (!rootElement) {
+            return
+        }
+
+        let rafId: number | null = null
+
+        const handleCompositionUpdate = () => {
+            if (rafId !== null) {
+                cancelAnimationFrame(rafId)
+            }
+            rafId = requestAnimationFrame(() => {
+                rafId = null
+
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                if ((editor as any)._compositionKey == null) {
+                    return
+                }
+
+                bypassComposingRef.current = true
+                try {
+                    editor.update(
+                        () => {
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            (editor as any)._dirtyType = HAS_DIRTY_NODES
+                        },
+                        {discrete: true, tag: SKIP_DOM_SELECTION_TAG},
+                    )
+                } finally {
+                    bypassComposingRef.current = false
+                }
+            })
+        }
+
+        rootElement.addEventListener('compositionupdate', handleCompositionUpdate)
+
+        return () => {
+            rootElement.removeEventListener('compositionupdate', handleCompositionUpdate)
+            if (rafId !== null) {
+                cancelAnimationFrame(rafId)
+            }
+        }
+    }, [editor])
+
+    // Handle Korean IME composition + Enter key interaction.
+    useEffect(() => {
+        const rootElement = editor.getRootElement()
+        if (!rootElement) {
+            return
+        }
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && e.isComposing) {
+                enterDuringCompositionRef.current = true
+            }
+        }
+
+        const handleCompositionEnd = () => {
+            if (!enterDuringCompositionRef.current) {
+                return
+            }
+            enterDuringCompositionRef.current = false
+
+            const removeListener = editor.registerUpdateListener(() => {
+                removeListener()
+                setTimeout(() => {
+                    editor.dispatchCommand(KEY_ENTER_COMMAND, null)
+                }, 150)
+            })
+        }
+
+        rootElement.addEventListener('keydown', handleKeyDown, true)
+        rootElement.addEventListener('compositionend', handleCompositionEnd)
+
+        return () => {
+            rootElement.removeEventListener('keydown', handleKeyDown, true)
+            rootElement.removeEventListener('compositionend', handleCompositionEnd)
+        }
+    }, [editor])
+
+    return null
+}
+
+export default CompositionPlugin

--- a/webapp/src/widgets/editable.tsx
+++ b/webapp/src/widgets/editable.tsx
@@ -19,7 +19,6 @@ export type EditableProps = {
     onCancel?: () => void
     onSave?: (saveType: 'onEnter'|'onEsc'|'onBlur') => void
     onFocus?: () => void
-    ref?: React.Ref<Focusable>
 }
 
 export type Focusable = {
@@ -118,10 +117,9 @@ export function useEditable(
     }
 }
 
-const Editable = (props: EditableProps): React.JSX.Element => {
-    const { ref, ...otherProps } = props
+const Editable = React.forwardRef<Focusable, EditableProps>((props, ref) => {
     const elementRef = useRef<HTMLInputElement>(null)
-    const elementProps = useEditable(otherProps, ref, elementRef as React.RefObject<ElementType>)
+    const elementProps = useEditable(props, ref, elementRef as React.RefObject<ElementType>)
 
     useLayoutEffect(() => {
         if (props.autoExpand && elementRef.current) {
@@ -136,6 +134,7 @@ const Editable = (props: EditableProps): React.JSX.Element => {
             ref={elementRef}
         />
     )
-}
+})
+Editable.displayName = 'Editable'
 
 export default Editable

--- a/webapp/src/widgets/editableArea.tsx
+++ b/webapp/src/widgets/editableArea.tsx
@@ -11,12 +11,11 @@ function getBorderWidth(style: CSSStyleDeclaration): number {
     return parseInt(style.borderTopWidth || '0', 10) + parseInt(style.borderBottomWidth || '0', 10)
 }
 
-const EditableArea = (props: EditableProps): React.JSX.Element => {
-    const { ref, ...otherProps } = props
+const EditableArea = React.forwardRef<Focusable, EditableProps>((props, ref) => {
     const elementRef = useRef<HTMLTextAreaElement>(null)
     const referenceRef = useRef<HTMLTextAreaElement>(null)
     const heightRef = useRef(0)
-    const elementProps = useEditable(otherProps, ref, elementRef as React.RefObject<ElementType>)
+    const elementProps = useEditable(props, ref, elementRef as React.RefObject<ElementType>)
 
     useEffect(() => {
         if (!elementRef.current || !referenceRef.current) {
@@ -63,6 +62,7 @@ const EditableArea = (props: EditableProps): React.JSX.Element => {
             </div>
         </div>
     )
-}
+})
+EditableArea.displayName = 'EditableArea'
 
 export default EditableArea


### PR DESCRIPTION
- 한국어 IME 조합 중 타이프어헤드 및 Enter 키 동작을 개선하는 CompositionPlugin 추가
- MentionsMenu에 forwardRef 적용하여 React 통합 개선
- Editable 및 EditableArea 컴포넌트에 forwardRef 적용하여 유연성 및 사용성 향상
- lexicalEditor.scss 스타일 조정으로 레이아웃 및 UX 개선 (최소 너비, 패딩 조정)