### PR TITLE
fix: 아카이브 import/export 콘텐츠 및 파일 복원 안정화

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,10 @@ endif
 webapp: webapp/node_modules
 ifneq ($(HAS_WEBAPP),)
 ifeq ($(MM_DEBUG),)
+	rm -rf webapp/dist
 	cd webapp && $(NPM) run build;
 else
+	rm -rf webapp/dist
 	cd webapp && $(NPM) run debug;
 endif
 endif
@@ -173,7 +175,7 @@ endif
 ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_NAME)/webapp
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_NAME)
+	cd dist && COPYFILE_DISABLE=1 tar -cvzf $(BUNDLE_NAME) $(PLUGIN_NAME)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 

--- a/server/app/export.go
+++ b/server/app/export.go
@@ -15,6 +15,20 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
+// archiveBlockSuiteDoc is used for serializing BlockSuiteDoc in archive files.
+// The Snapshot field uses json:"snapshot" (not "-") so it gets base64-encoded.
+type archiveBlockSuiteDoc struct {
+	DocID       string `json:"docId"`
+	CardID      string `json:"cardId"`
+	BoardID     string `json:"boardId"`
+	Snapshot    []byte `json:"snapshot"`
+	ContentText string `json:"contentText,omitempty"`
+}
+
+type archiveFilesMeta struct {
+	Files map[string]string `json:"files"`
+}
+
 var (
 	newline = []byte{'\n'}
 )
@@ -114,13 +128,152 @@ func (a *App) writeArchiveBoard(zw *zip.Writer, board model.Board, opt model.Exp
 		}
 	}
 
-	// write the files
+	// write BlockSuite docs
+	bsDocs, err := a.store.GetBlockSuiteDocsByBoardID(board.ID)
+	if err != nil {
+		return err
+	}
+	bsDocsByCardID := make(map[string]*model.BlockSuiteDoc, len(bsDocs))
+	for _, doc := range bsDocs {
+		bsDocsByCardID[doc.CardID] = doc
+		if err = a.writeArchiveBlockSuiteDocLine(w, doc); err != nil {
+			return err
+		}
+		// collect file IDs embedded in BlockSuite snapshots (affine:image via blobMap)
+		for _, fileID := range extractBlockSuiteFileIDs(doc.Snapshot) {
+			files = append(files, fileID)
+		}
+	}
+
+	// write per-card markdown files
+	a.writeArchiveCardMarkdownFiles(zw, board, blocks, bsDocsByCardID)
+
+	// Persist original display names so import can restore attachment titles.
+	if err := a.writeArchiveFilesMeta(zw, board.ID, files); err != nil {
+		return err
+	}
+
+	// write the files (legacy blocks + BlockSuite embedded images)
 	for _, filename := range files {
 		if err := a.writeArchiveFile(zw, filename, board.ID, opt); err != nil {
 			return fmt.Errorf("cannot write file %s to archive: %w", filename, err)
 		}
 	}
 	return nil
+}
+
+// extractBlockSuiteFileIDs parses a BlockSuite snapshot and returns all blob/file IDs
+// registered in the snapshot's blobMap (used by affine:image blocks).
+func extractBlockSuiteFileIDs(snapshot []byte) []string {
+	if len(snapshot) == 0 {
+		return nil
+	}
+	var ds DocSnapshot
+	if err := json.Unmarshal(snapshot, &ds); err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(ds.Meta.BlobMap))
+	for _, fileID := range ds.Meta.BlobMap {
+		if fileID != "" {
+			ids = append(ids, fileID)
+		}
+	}
+	return ids
+}
+
+// writeArchiveBlockSuiteDocLine writes a single BlockSuite document to the archive.
+func (a *App) writeArchiveBlockSuiteDocLine(w io.Writer, doc *model.BlockSuiteDoc) error {
+	archiveDoc := archiveBlockSuiteDoc{
+		DocID:       doc.DocID,
+		CardID:      doc.CardID,
+		BoardID:     doc.BoardID,
+		Snapshot:    doc.Snapshot,
+		ContentText: doc.ContentText,
+	}
+	b, err := json.Marshal(&archiveDoc)
+	if err != nil {
+		return err
+	}
+	line := model.ArchiveLine{
+		Type: "blocksuitedoc",
+		Data: b,
+	}
+	b, err = json.Marshal(&line)
+	if err != nil {
+		return err
+	}
+	if _, err = w.Write(b); err != nil {
+		return err
+	}
+	_, err = w.Write(newline)
+	return err
+}
+
+// writeArchiveCardMarkdownFiles writes a .md file for each card into the archive.
+func (a *App) writeArchiveCardMarkdownFiles(zw *zip.Writer, board model.Board, blocks []*model.Block, bsDocsByCardID map[string]*model.BlockSuiteDoc) {
+	for _, block := range blocks {
+		if block.Type != model.TypeCard {
+			continue
+		}
+
+		bsDoc := bsDocsByCardID[block.ID]
+		md := cardToMarkdown(board, block, blocks, bsDoc)
+
+		filename := sanitizeFilename(block.Title)
+		if filename == "" {
+			filename = block.ID
+		}
+
+		fw, err := zw.Create(board.ID + "/cards/" + filename + ".md")
+		if err != nil {
+			a.logger.Warn("cannot create .md file in archive",
+				mlog.String("cardID", block.ID),
+				mlog.Err(err),
+			)
+			continue
+		}
+		if _, err := io.WriteString(fw, md); err != nil {
+			a.logger.Warn("cannot write .md file in archive",
+				mlog.String("cardID", block.ID),
+				mlog.Err(err),
+			)
+		}
+	}
+}
+
+func (a *App) writeArchiveFilesMeta(zw *zip.Writer, boardID string, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	meta := make(map[string]string, len(files))
+	for _, archiveFileName := range files {
+		if _, exists := meta[archiveFileName]; exists {
+			continue
+		}
+
+		fileInfo, err := a.GetFileInfo(archiveFileName)
+		if err != nil || fileInfo == nil || fileInfo.Name == "" {
+			continue
+		}
+		meta[archiveFileName] = fileInfo.Name
+	}
+
+	if len(meta) == 0 {
+		return nil
+	}
+
+	payload, err := json.Marshal(&archiveFilesMeta{Files: meta})
+	if err != nil {
+		return err
+	}
+
+	w, err := zw.Create(boardID + "/files_meta.json")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(payload)
+	return err
 }
 
 // writeArchiveBoardMemberLine writes a single boardMember to the archive.
@@ -207,22 +360,41 @@ func (a *App) writeArchiveFile(zw *zip.Writer, filename string, boardID string, 
 		return err
 	}
 
-	_, fileReader, err := a.GetFile(opt.TeamID, boardID, filename)
-	if err != nil && !model.IsErrNotFound(err) {
+	// Use GetFilePath + filesBackend.Reader directly to bypass ValidateFileOwnership.
+	// ValidateFileOwnership fails for BlockSuite-uploaded files because their storage path
+	// (boards/YYYYMMDD/fileId) does not match the expected path (teamID/boardID/fileId).
+	// Export is a trusted admin operation so ownership validation is not required here.
+	_, filePath, err := a.GetFilePath(opt.TeamID, boardID, filename)
+	if err != nil {
+		a.logger.Error("archive file missing for export",
+			mlog.String("filename", filename),
+			mlog.String("team_id", opt.TeamID),
+			mlog.String("board_id", boardID),
+			mlog.Err(err),
+		)
+		return nil
+	}
+
+	exists, err := a.filesBackend.FileExists(filePath)
+	if err != nil {
 		return err
 	}
-	if err != nil {
-		// just log this; image file is missing but we'll still export an equivalent board
-		a.logger.Error("image file missing for export",
+	if !exists {
+		a.logger.Error("archive file missing for export",
 			mlog.String("filename", filename),
 			mlog.String("team_id", opt.TeamID),
 			mlog.String("board_id", boardID),
 		)
 		return nil
 	}
-	defer fileReader.Close()
 
-	_, err = io.Copy(dest, fileReader)
+	reader, err := a.filesBackend.Reader(filePath)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	_, err = io.Copy(dest, reader)
 	return err
 }
 
@@ -242,17 +414,20 @@ func (a *App) getBoardsForArchive(boardIDs []string) ([]model.Board, error) {
 }
 
 func extractFilename(block *model.Block) (string, error) {
-	f, ok := block.Fields["fileId"]
-	if !ok {
-		f, ok = block.Fields["attachmentId"]
-		if !ok {
-			return "", model.ErrInvalidImageBlock
+	// Attachment blocks are normalized as attachmentId first in the webapp,
+	// while image blocks use fileId first. Keep archive export aligned.
+	fieldOrder := []string{model.BlockFieldFileId, model.BlockFieldAttachmentId}
+	if block.Type == model.TypeAttachment {
+		fieldOrder = []string{model.BlockFieldAttachmentId, model.BlockFieldFileId}
+	}
+
+	for _, field := range fieldOrder {
+		if value, ok := block.Fields[field]; ok {
+			if filename, ok := value.(string); ok && filename != "" {
+				return filename, nil
+			}
 		}
 	}
 
-	filename, ok := f.(string)
-	if !ok {
-		return "", model.ErrInvalidImageBlock
-	}
-	return filename, nil
+	return "", model.ErrInvalidImageBlock
 }

--- a/server/app/export_markdown.go
+++ b/server/app/export_markdown.go
@@ -1,0 +1,382 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
+)
+
+// cardToMarkdown converts a card and its related blocks to a Markdown string.
+func cardToMarkdown(board model.Board, card *model.Block, allBlocks []*model.Block, bsDoc *model.BlockSuiteDoc) string {
+	var sb strings.Builder
+
+	// Title
+	sb.WriteString("# " + card.Title + "\n\n")
+
+	// Properties table
+	if props := cardPropertiesToMarkdown(board, card); props != "" {
+		sb.WriteString(props)
+	}
+
+	// Content: prefer BlockSuite snapshot, fall back to legacy blocks
+	var contentMD string
+	if bsDoc != nil && len(bsDoc.Snapshot) > 0 {
+		contentMD = docSnapshotToMarkdown(bsDoc.Snapshot)
+	} else {
+		contentMD = legacyBlocksToMarkdown(card.ID, allBlocks)
+	}
+	if contentMD != "" {
+		sb.WriteString("## Content\n\n")
+		sb.WriteString(contentMD)
+		sb.WriteString("\n")
+	}
+
+	// Comments
+	if comments := commentsToMarkdown(card.ID, allBlocks); comments != "" {
+		sb.WriteString(comments)
+	}
+
+	return sb.String()
+}
+
+// cardPropertiesToMarkdown generates a Markdown table for card properties.
+func cardPropertiesToMarkdown(board model.Board, card *model.Block) string {
+	propsRaw, ok := card.Fields["properties"].(map[string]interface{})
+	if !ok || len(propsRaw) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Properties\n\n")
+	sb.WriteString("| Property | Value |\n")
+	sb.WriteString("| -------- | ----- |\n")
+
+	hasRows := false
+	for _, propDef := range board.CardProperties {
+		propID, _ := propDef["id"].(string)
+		propName, _ := propDef["name"].(string)
+		propType, _ := propDef["type"].(string)
+
+		rawVal, hasVal := propsRaw[propID]
+		if !hasVal {
+			continue
+		}
+		valStr := resolvePropertyValue(propDef, propType, rawVal)
+		if valStr == "" {
+			continue
+		}
+		sb.WriteString("| " + propName + " | " + valStr + " |\n")
+		hasRows = true
+	}
+
+	if !hasRows {
+		return ""
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// resolvePropertyValue converts a raw property value to a display string.
+func resolvePropertyValue(propDef map[string]interface{}, propType string, rawVal interface{}) string {
+	switch propType {
+	case "select":
+		optID, ok := rawVal.(string)
+		if !ok {
+			return fmt.Sprintf("%v", rawVal)
+		}
+		opts, _ := propDef["options"].([]interface{})
+		for _, o := range opts {
+			opt, _ := o.(map[string]interface{})
+			if opt["id"] == optID {
+				name, _ := opt["value"].(string)
+				return name
+			}
+		}
+		return optID
+	case "multiSelect":
+		ids, ok := rawVal.([]interface{})
+		if !ok {
+			return fmt.Sprintf("%v", rawVal)
+		}
+		opts, _ := propDef["options"].([]interface{})
+		optMap := make(map[string]string)
+		for _, o := range opts {
+			opt, _ := o.(map[string]interface{})
+			id, _ := opt["id"].(string)
+			val, _ := opt["value"].(string)
+			optMap[id] = val
+		}
+		var names []string
+		for _, id := range ids {
+			idStr, _ := id.(string)
+			if name, ok := optMap[idStr]; ok {
+				names = append(names, name)
+			}
+		}
+		return strings.Join(names, ", ")
+	case "checkbox":
+		if b, ok := rawVal.(bool); ok {
+			if b {
+				return "Yes"
+			}
+			return "No"
+		}
+		return fmt.Sprintf("%v", rawVal)
+	default:
+		return fmt.Sprintf("%v", rawVal)
+	}
+}
+
+// legacyBlocksToMarkdown converts legacy content blocks (pre-BlockSuite) to Markdown.
+func legacyBlocksToMarkdown(cardID string, allBlocks []*model.Block) string {
+	var sb strings.Builder
+	for _, block := range allBlocks {
+		if block.ParentID != cardID {
+			continue
+		}
+		if block.Type == model.TypeComment || block.Type == model.TypeCard || block.Type == model.TypeView {
+			continue
+		}
+		line := legacyBlockToMarkdownLine(block)
+		if line != "" {
+			sb.WriteString(line + "\n")
+		}
+	}
+	return sb.String()
+}
+
+// legacyBlockToMarkdownLine converts a single legacy block to a Markdown line.
+func legacyBlockToMarkdownLine(block *model.Block) string {
+	switch block.Type {
+	case model.TypeText:
+		return block.Title
+	case "h1":
+		return "# " + block.Title
+	case "h2":
+		return "## " + block.Title
+	case "h3":
+		return "### " + block.Title
+	case model.TypeCheckbox:
+		if checked, ok := block.Fields["value"].(bool); ok && checked {
+			return "- [x] " + block.Title
+		}
+		return "- [ ] " + block.Title
+	case model.TypeDivider:
+		return "---"
+	case model.TypeImage:
+		if fileID, ok := block.Fields["fileId"].(string); ok {
+			return "![](" + fileID + ")"
+		}
+		return ""
+	case model.TypeAttachment:
+		fileID := ""
+		filename := block.Title
+		if fid, ok := block.Fields["attachmentId"].(string); ok {
+			fileID = fid
+		} else if fid, ok := block.Fields["fileId"].(string); ok {
+			fileID = fid
+		}
+		if filename == "" {
+			filename = fileID
+		}
+		return "[" + filename + "](" + fileID + ")"
+	case "quote":
+		return "> " + block.Title
+	default:
+		return block.Title
+	}
+}
+
+// commentsToMarkdown converts comment blocks to a Markdown section.
+func commentsToMarkdown(cardID string, allBlocks []*model.Block) string {
+	var comments []*model.Block
+	for _, block := range allBlocks {
+		if block.ParentID == cardID && block.Type == model.TypeComment {
+			comments = append(comments, block)
+		}
+	}
+	if len(comments) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Comments\n\n")
+	for _, comment := range comments {
+		sb.WriteString("**" + comment.CreatedBy + "**:\n")
+		sb.WriteString(comment.Title + "\n\n")
+	}
+	return sb.String()
+}
+
+// docSnapshotToMarkdown converts a BlockSuite DocSnapshot (JSON bytes) to Markdown.
+func docSnapshotToMarkdown(snapshot []byte) string {
+	if len(snapshot) == 0 {
+		return ""
+	}
+	var ds DocSnapshot
+	if err := json.Unmarshal(snapshot, &ds); err != nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	renderBlockSuiteNode(&sb, ds.Blocks, 0)
+	return strings.TrimSpace(sb.String())
+}
+
+// renderBlockSuiteNode recursively renders a BlockSnapshot node to Markdown.
+func renderBlockSuiteNode(sb *strings.Builder, node BlockSnapshot, depth int) {
+	switch node.Flavour {
+	case "affine:page", "affine:note":
+		for _, child := range node.Children {
+			renderBlockSuiteNode(sb, child, depth)
+		}
+	case "affine:surface":
+		// skip canvas/whiteboard surface
+
+	case "affine:heading":
+		level := 1
+		if t, ok := node.Props["type"].(string); ok && len(t) == 2 && t[0] == 'h' {
+			if n := int(t[1] - '0'); n >= 1 && n <= 6 {
+				level = n
+			}
+		}
+		text := deltaPropToMarkdown(node.Props)
+		sb.WriteString(strings.Repeat("#", level) + " " + text + "\n\n")
+
+	case "affine:paragraph":
+		text := deltaPropToMarkdown(node.Props)
+		if text != "" {
+			sb.WriteString(text + "\n\n")
+		}
+		for _, child := range node.Children {
+			renderBlockSuiteNode(sb, child, depth+1)
+		}
+
+	case "affine:list":
+		listType := "bulleted"
+		if t, ok := node.Props["type"].(string); ok {
+			listType = t
+		}
+		checked, _ := node.Props["checked"].(bool)
+		text := deltaPropToMarkdown(node.Props)
+		indent := strings.Repeat("  ", depth)
+		switch listType {
+		case "numbered":
+			sb.WriteString(indent + "1. " + text + "\n")
+		case "todo":
+			if checked {
+				sb.WriteString(indent + "- [x] " + text + "\n")
+			} else {
+				sb.WriteString(indent + "- [ ] " + text + "\n")
+			}
+		default:
+			sb.WriteString(indent + "- " + text + "\n")
+		}
+		for _, child := range node.Children {
+			renderBlockSuiteNode(sb, child, depth+1)
+		}
+		if depth == 0 {
+			sb.WriteString("\n")
+		}
+
+	case "affine:divider":
+		sb.WriteString("---\n\n")
+
+	case "affine:code":
+		lang, _ := node.Props["language"].(string)
+		text := deltaPropToMarkdown(node.Props)
+		sb.WriteString("```" + lang + "\n" + text + "\n```\n\n")
+
+	case "affine:image":
+		src, _ := node.Props["sourceId"].(string)
+		sb.WriteString("![](" + src + ")\n\n")
+
+	default:
+		text := deltaPropToMarkdown(node.Props)
+		if text != "" {
+			sb.WriteString(text + "\n\n")
+		}
+		for _, child := range node.Children {
+			renderBlockSuiteNode(sb, child, depth)
+		}
+	}
+}
+
+// deltaPropToMarkdown converts the "text" prop of a BlockSnapshot to inline Markdown.
+func deltaPropToMarkdown(props map[string]interface{}) string {
+	textProp, ok := props["text"]
+	if !ok {
+		return ""
+	}
+	// textProp is a BlockSuiteText-like map: { "delta": [...], "$blocksuite:internal:text$": true }
+	textMap, ok := textProp.(map[string]interface{})
+	if !ok {
+		if s, ok := textProp.(string); ok {
+			return s
+		}
+		return ""
+	}
+
+	deltaRaw, ok := textMap["delta"]
+	if !ok {
+		return ""
+	}
+	deltaArr, ok := deltaRaw.([]interface{})
+	if !ok {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, item := range deltaArr {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		insert, _ := itemMap["insert"].(string)
+		var attrs map[string]interface{}
+		if a, ok := itemMap["attributes"].(map[string]interface{}); ok {
+			attrs = a
+		}
+		sb.WriteString(applyInlineMarkdown(insert, attrs))
+	}
+	return sb.String()
+}
+
+// applyInlineMarkdown applies bold/italic/code/link formatting to a text string.
+func applyInlineMarkdown(text string, attrs map[string]interface{}) string {
+	if text == "" || attrs == nil {
+		return text
+	}
+	if bold, _ := attrs["bold"].(bool); bold {
+		text = "**" + text + "**"
+	}
+	if italic, _ := attrs["italic"].(bool); italic {
+		text = "*" + text + "*"
+	}
+	if code, _ := attrs["code"].(bool); code {
+		text = "`" + text + "`"
+	}
+	if link, _ := attrs["link"].(string); link != "" {
+		text = "[" + text + "](" + link + ")"
+	}
+	return text
+}
+
+var invalidFilenameChars = regexp.MustCompile(`[/\\:*?"<>|]`)
+
+// sanitizeFilename removes characters that are invalid in filenames.
+func sanitizeFilename(name string) string {
+	name = invalidFilenameChars.ReplaceAllString(name, "_")
+	name = strings.TrimSpace(name)
+	name = strings.Trim(name, ".")
+	if len(name) > 100 {
+		name = name[:100]
+	}
+	return name
+}

--- a/server/app/import.go
+++ b/server/app/import.go
@@ -53,12 +53,14 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 
 	boardMap := make(map[string]*model.Board) // maps old board ids to new
 	fileMap := make(map[string]string)        // maps old fileIds to new
+	fileNamesMap := make(map[string]map[string]string)
 
 	for {
 		hdr, err := zr.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				a.fixImagesAttachments(boardMap, fileMap, opt.TeamID, opt.ModifiedBy)
+				a.fixBlockSuiteDocFileIDs(boardMap, fileMap)
 				a.logger.Debug("import archive - done", mlog.Int("boards_imported", len(boardMap)))
 				return nil
 			}
@@ -83,9 +85,26 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 				return fmt.Errorf("cannot import board %s: %w", dir, err)
 			}
 			boardMap[dir] = board
+		case "files_meta.json":
+			var meta archiveFilesMeta
+			if err := json.NewDecoder(zr).Decode(&meta); err != nil {
+				a.logger.Warn("cannot parse files_meta.json, falling back to archive entry names",
+					mlog.String("dir", dir),
+					mlog.Err(err),
+				)
+				continue
+			}
+			if len(meta.Files) > 0 {
+				fileNamesMap[dir] = meta.Files
+			}
 		default:
-			// import file/image;  dir is the old board id
+			// Skip only generated card markdown files under "<boardID>/cards/*.md".
+			// Real user attachments can also be ".md", and must still be imported.
+			if strings.HasSuffix(filename, ".md") && path.Base(dir) == "cards" {
+				continue
+			}
 
+			// import file/image;  dir is the old board id
 			board, ok := boardMap[dir]
 			if !ok {
 				a.logger.Warn("skipping orphan image in archive",
@@ -94,7 +113,14 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 				)
 				continue
 			}
-			newFileName, err := a.SaveFile(zr, opt.TeamID, board.ID, filename, board.IsTemplate)
+			displayName := filename
+			if boardFilesMeta, exists := fileNamesMap[dir]; exists {
+				if originalName, ok := boardFilesMeta[filename]; ok && originalName != "" {
+					displayName = originalName
+				}
+			}
+
+			newFileName, err := a.SaveFile(zr, opt.TeamID, board.ID, displayName, board.IsTemplate)
 			if err != nil {
 				return fmt.Errorf("cannot import file %s for board %s: %w", filename, dir, err)
 			}
@@ -104,6 +130,7 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 				mlog.String("TeamID", opt.TeamID),
 				mlog.String("boardID", board.ID),
 				mlog.String("filename", filename),
+				mlog.String("displayName", displayName),
 				mlog.String("newFileName", newFileName),
 			)
 		}
@@ -112,12 +139,12 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 
 // Update image and attachment blocks.
 func (a *App) fixImagesAttachments(boardMap map[string]*model.Board, fileMap map[string]string, teamID string, userID string) {
-	blockIDs := make([]string, 0)
-	blockPatches := make([]model.BlockPatch, 0)
 	for _, board := range boardMap {
 		if board.IsTemplate {
 			continue
 		}
+		blockIDs := make([]string, 0)
+		blockPatches := make([]model.BlockPatch, 0)
 
 		opts := model.QueryBlocksOptions{
 			BoardID: board.ID,
@@ -129,23 +156,67 @@ func (a *App) fixImagesAttachments(boardMap map[string]*model.Board, fileMap map
 		}
 
 		for _, block := range newBlocks {
-			if block.Type == "image" || block.Type == "attachment" {
-				fieldName := "fileId"
-				oldID := block.Fields[fieldName]
-				blockIDs = append(blockIDs, block.ID)
-
-				blockPatches = append(blockPatches, model.BlockPatch{
-					UpdatedFields: map[string]interface{}{
-						fieldName: fileMap[oldID.(string)],
-					},
-				})
+			if block.DeleteAt > 0 {
+				continue
 			}
+			if block.Type != model.TypeImage && block.Type != model.TypeAttachment {
+				continue
+			}
+
+			var fieldName, newID string
+			if fid, ok := block.Fields[model.BlockFieldFileId].(string); ok && fid != "" {
+				if mapped, exists := fileMap[fid]; exists {
+					fieldName = model.BlockFieldFileId
+					newID = mapped
+				}
+			}
+			if newID == "" {
+				if aid, ok := block.Fields[model.BlockFieldAttachmentId].(string); ok && aid != "" {
+					if mapped, exists := fileMap[aid]; exists {
+						fieldName = model.BlockFieldAttachmentId
+						newID = mapped
+					}
+				}
+			}
+			if newID == "" {
+				a.logger.Debug("fixImagesAttachments: no fileMap entry for block",
+					mlog.String("blockID", block.ID),
+					mlog.String("boardID", board.ID),
+					mlog.String("fileId", fmt.Sprintf("%v", block.Fields[model.BlockFieldFileId])),
+					mlog.String("attachmentId", fmt.Sprintf("%v", block.Fields[model.BlockFieldAttachmentId])),
+				)
+				continue
+			}
+
+			blockIDs = append(blockIDs, block.ID)
+			var deleteField string
+			if fieldName == model.BlockFieldFileId {
+				deleteField = model.BlockFieldAttachmentId
+			} else {
+				deleteField = model.BlockFieldFileId
+			}
+			blockPatches = append(blockPatches, model.BlockPatch{
+				UpdatedFields: map[string]interface{}{fieldName: newID},
+				DeletedFields: []string{deleteField},
+			})
+		}
+
+		if len(blockIDs) == 0 {
+			continue
 		}
 
 		blockPatchBatch := model.BlockPatchBatch{BlockIDs: blockIDs, BlockPatches: blockPatches}
-		err = a.PatchBlocks(teamID, &blockPatchBatch, userID)
-		if err != nil {
-			a.logger.Info("Error patching blocks for image import", mlog.Err(err))
+		if err = a.PatchBlocksAndNotify(teamID, &blockPatchBatch, userID, true); err != nil {
+			a.logger.Warn("fixImagesAttachments: failed to patch file IDs",
+				mlog.String("boardID", board.ID),
+				mlog.Int("patchCount", len(blockIDs)),
+				mlog.Err(err),
+			)
+		} else {
+			a.logger.Debug("fixImagesAttachments: patched file IDs",
+				mlog.String("boardID", board.ID),
+				mlog.Int("patchCount", len(blockIDs)),
+			)
 		}
 	}
 }
@@ -161,11 +232,14 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 	}
 	lineReader := &io.LimitedReader{R: r, N: importMaxFileSize + 1}
 	scanner := bufio.NewScanner(lineReader)
+	// BlockSuite snapshot lines can be large; increase scanner buffer to 10MB per line.
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), 10*1024*1024)
 
 	userID := opt.ModifiedBy
 	now := utils.GetMillis()
 	var boardID string
 	var boardMembers []*model.BoardMember
+	var blockSuiteDocs []*archiveBlockSuiteDoc
 
 	lineNum := 1
 	firstLine := true
@@ -235,15 +309,25 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 					block.UpdateAt = now
 					block.BoardID = boardID
 					boardsAndBlocks.Blocks = append(boardsAndBlocks.Blocks, block)
-				case "boardMember":
-					var boardMember *model.BoardMember
-					if err2 := json.Unmarshal(archiveLine.Data, &boardMember); err2 != nil {
-						return nil, fmt.Errorf("invalid board Member in archive line %d: %w", lineNum, err2)
-					}
-					boardMembers = append(boardMembers, boardMember)
-				default:
-					return nil, model.NewErrUnsupportedArchiveLineType(lineNum, archiveLine.Type)
+			case "boardMember":
+				var boardMember *model.BoardMember
+				if err2 := json.Unmarshal(archiveLine.Data, &boardMember); err2 != nil {
+					return nil, fmt.Errorf("invalid board Member in archive line %d: %w", lineNum, err2)
 				}
+				boardMembers = append(boardMembers, boardMember)
+			case "blocksuitedoc":
+				var doc archiveBlockSuiteDoc
+				if err2 := json.Unmarshal(archiveLine.Data, &doc); err2 != nil {
+					return nil, fmt.Errorf("invalid blocksuitedoc in archive line %d: %w", lineNum, err2)
+				}
+				blockSuiteDocs = append(blockSuiteDocs, &doc)
+			default:
+				// Skip unknown line types for forward compatibility
+				a.logger.Warn("skipping unknown archive line type",
+					mlog.Int("lineNum", lineNum),
+					mlog.String("type", archiveLine.Type),
+				)
+			}
 				firstLine = false
 			}
 		}
@@ -263,7 +347,8 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 	a.fixBoardsandBlocks(boardsAndBlocks, opt)
 
 	var err error
-	boardsAndBlocks, err = model.GenerateBoardsAndBlocksIDs(boardsAndBlocks, a.logger)
+	var cardIDMapping map[string]string
+	boardsAndBlocks, cardIDMapping, err = model.GenerateBoardsAndBlocksIDsWithMapping(boardsAndBlocks, a.logger)
 	if err != nil {
 		return nil, fmt.Errorf("error generating archive block IDs: %w", err)
 	}
@@ -276,6 +361,14 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 	if err := a.addUserToNewBoard(boardsAndBlocks, opt, boardMembers); err != nil {
 		return nil, err
 	}
+
+	// import BlockSuite docs with remapped IDs (after cards are in DB)
+	var newBoardID string
+	for _, board := range boardsAndBlocks.Boards {
+		newBoardID = board.ID
+		break
+	}
+	a.importBlockSuiteDocs(blockSuiteDocs, cardIDMapping, newBoardID)
 
 	// find new board id
 	for _, board := range boardsAndBlocks.Boards {
@@ -465,6 +558,75 @@ func arrayMapsValue(m map[string]interface{}, key string) ([]map[string]interfac
 		arr = append(arr, mm)
 	}
 	return arr, true
+}
+
+// importBlockSuiteDocs saves BlockSuite documents with remapped card/board IDs.
+// Must be called after CreateBoardsAndBlocks so parent cards exist.
+func (a *App) importBlockSuiteDocs(docs []*archiveBlockSuiteDoc, cardIDMapping map[string]string, newBoardID string) {
+	for _, doc := range docs {
+		newCardID, ok := cardIDMapping[doc.CardID]
+		if !ok {
+			a.logger.Warn("skipping blocksuite doc with unknown card ID",
+				mlog.String("oldCardID", doc.CardID),
+			)
+			continue
+		}
+		newDoc := &model.BlockSuiteDoc{
+			DocID:       newCardID,
+			CardID:      newCardID,
+			BoardID:     newBoardID,
+			Snapshot:    doc.Snapshot,
+			ContentText: doc.ContentText,
+		}
+		if err := a.store.UpsertBlockSuiteDoc(newDoc); err != nil {
+			a.logger.Warn("cannot import blocksuite doc",
+				mlog.String("cardID", newCardID),
+				mlog.Err(err),
+			)
+		}
+	}
+}
+
+// fixBlockSuiteDocFileIDs replaces old file IDs with new file IDs inside BlockSuite snapshots.
+func (a *App) fixBlockSuiteDocFileIDs(boardMap map[string]*model.Board, fileMap map[string]string) {
+	if len(fileMap) == 0 {
+		return
+	}
+	for _, board := range boardMap {
+		if board.IsTemplate {
+			continue
+		}
+		docs, err := a.store.GetBlockSuiteDocsByBoardID(board.ID)
+		if err != nil {
+			a.logger.Warn("fixBlockSuiteDocFileIDs: cannot get docs",
+				mlog.String("boardID", board.ID),
+				mlog.Err(err),
+			)
+			continue
+		}
+		for _, doc := range docs {
+			if len(doc.Snapshot) == 0 {
+				continue
+			}
+			snapshotStr := string(doc.Snapshot)
+			changed := false
+			for oldID, newID := range fileMap {
+				if strings.Contains(snapshotStr, oldID) {
+					snapshotStr = strings.ReplaceAll(snapshotStr, oldID, newID)
+					changed = true
+				}
+			}
+			if changed {
+				doc.Snapshot = []byte(snapshotStr)
+				if err := a.store.UpsertBlockSuiteDoc(doc); err != nil {
+					a.logger.Warn("fixBlockSuiteDocFileIDs: cannot update doc",
+						mlog.String("docID", doc.DocID),
+						mlog.Err(err),
+					)
+				}
+			}
+		}
+	}
 }
 
 func parseVersionFile(r io.Reader) (int, error) {

--- a/webapp/src/components/content/attachmentElement.tsx
+++ b/webapp/src/components/content/attachmentElement.tsx
@@ -117,8 +117,12 @@ const AttachmentElement = (props: Props): React.JSX.Element|null => {
 
     const attachmentDownloadHandler = async () => {
         const attachment = await octoClient.getFileAsDataUrl(block.boardId, block.fields.fileId)
+        if (!attachment.url) {
+            Utils.logWarn(`Attachment download skipped: missing URL for board=${block.boardId} fileId=${block.fields.fileId}`)
+            return
+        }
         const anchor = document.createElement('a')
-        anchor.href = attachment.url || ''
+        anchor.href = attachment.url
         anchor.download = fileInfo.name || ''
         document.body.appendChild(anchor)
         anchor.click()

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -660,6 +660,8 @@ class OctoClient {
             fileInfo = this.getJson(response, {}) as FileInfo
         } else if (response.status === 400) {
             fileInfo = await this.getJson(response, {}) as FileInfo
+        } else {
+            Utils.logWarn(`getFileInfo failed: status=${response.status} boardId=${boardId} fileId=${fileId}`)
         }
 
         return fileInfo
@@ -684,9 +686,15 @@ class OctoClient {
 
         if (response.status === 200) {
             const blob = await response.blob()
+            if (!blob || blob.size === 0) {
+                Utils.logWarn(`getFileAsDataUrl empty blob: boardId=${boardId} fileId=${fileId}`)
+                return fileInfo
+            }
             fileInfo.url = URL.createObjectURL(blob)
         } else if (response.status === 400) {
             fileInfo = await this.getJson(response, {}) as FileInfo
+        } else {
+            Utils.logWarn(`getFileAsDataUrl failed: status=${response.status} boardId=${boardId} fileId=${fileId}`)
         }
 
         return fileInfo


### PR DESCRIPTION
- 서버 간 이동 시 카드 텍스트 콘텐츠, 첨부파일, 이미지 복원이 깨지던 문제를 수정
- BlockSuite/legacy 콘텐츠와 파일 참조 ID를 올바르게 재매핑하고, import 시 원본 표시 이름 복원을 보장하도록 개선